### PR TITLE
jam-remote re-activate code signing check

### DIFF
--- a/scripts/jam-remote/install.jam.sh
+++ b/scripts/jam-remote/install.jam.sh
@@ -59,8 +59,8 @@ if [ "$1" = "on" ]; then
     cd jam || exit 1
     sudo -u $USERNAME git reset --hard ${WEBUI_VERSION}
 
-    #sudo -u $USERNAME bash ${SOURCEDIR}/../verify.git.sh \
-    #  "${PGPsigner}" "${PGPpubkeyLink}" "${PGPpubkeyFingerprint}" "v${WEBUI_VERSION}" || exit 1
+    sudo -u $USERNAME bash ${SOURCEDIR}/../verify.git.sh \
+      "${PGPsigner}" "${PGPpubkeyLink}" "${PGPpubkeyFingerprint}" "${WEBUI_VERSION}" || exit 1
 
     cd $HOME_DIR || exit 1
     sudo -u $USERNAME mv jam $APP_DIR

--- a/scripts/jam-remote/install.selfsignedcert.sh
+++ b/scripts/jam-remote/install.selfsignedcert.sh
@@ -3,10 +3,10 @@
 
 USERNAME=jam
 
-sudo apt install nginx
+sudo apt-get install -y nginx
 
 if ! sudo ls /home/jam/nginx/tls.cert || ! sudo ls  /home/jam/nginx/tls.key; then
-  sudo apt-get install openssl
+  sudo apt-get install -y openssl
 
   subj="/C=US/ST=Utah/L=Lehi/O=Your Company, Inc./OU=IT/CN=example.com"
   sudo -u $USERNAME mkdir -p /home/jam/nginx/ \


### PR DESCRIPTION
- jam-remote re-activate code signing check
- chore(install.selfsignedcert.sh): non-interactive script
