### PR TITLE
chore: migrate the watch-only Bitcoin Core wallet to use descriptors

### DIFF
--- a/.github/workflows/amd64-image-test.yml
+++ b/.github/workflows/amd64-image-test.yml
@@ -1,0 +1,136 @@
+name: amd64-image-test
+
+concurrency:
+  group: amd64-image-test-${{ github.event.workflow_run.id || inputs.run_id || github.run_id }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    branches: ["master"]
+    paths-ignore:
+      - '*.md'
+      - '.gitignore'
+      - 'images'
+      - 'ci/arm64-rpi/**'
+      - 'scripts/jam-remote'
+  workflow_run:
+    workflows: ["amd64-image-build"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "amd64-image-build workflow run ID to test"
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  bats-image-test:
+    name: Run Bats against amd64 image artifact
+    runs-on: ubuntu-22.04
+    timeout-minutes: 240
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name || github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha || github.ref }}
+
+      - name: Resolve amd64 image build run ID
+        id: build_run
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PROVIDED_RUN_ID: ${{ github.event.workflow_run.id || inputs.run_id }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "${PROVIDED_RUN_ID}" ]; then
+            echo "run_id=${PROVIDED_RUN_ID}" >>"${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          echo "Waiting for successful amd64-image-build run for ${HEAD_SHA}"
+          for attempt in {1..180}; do
+            active_run="$(
+              gh run list \
+                --repo "${GITHUB_REPOSITORY}" \
+                --workflow amd64-image-build.yml \
+                --commit "${HEAD_SHA}" \
+                --event pull_request \
+                --limit 20 \
+                --json databaseId,status,conclusion,createdAt \
+                --jq 'map(select(.status != "completed")) | first | .databaseId // ""'
+            )"
+
+            run_id="$(
+              gh run list \
+                --repo "${GITHUB_REPOSITORY}" \
+                --workflow amd64-image-build.yml \
+                --commit "${HEAD_SHA}" \
+                --event pull_request \
+                --limit 20 \
+                --json databaseId,status,conclusion,createdAt \
+                --jq 'map(select(.status == "completed" and .conclusion == "success")) | first | .databaseId // ""'
+            )"
+
+            if [ -n "${run_id}" ]; then
+              echo "run_id=${run_id}" >>"${GITHUB_OUTPUT}"
+              exit 0
+            fi
+
+            failed_run="$(
+              gh run list \
+                --repo "${GITHUB_REPOSITORY}" \
+                --workflow amd64-image-build.yml \
+                --commit "${HEAD_SHA}" \
+                --event pull_request \
+                --limit 20 \
+                --json databaseId,status,conclusion,createdAt \
+                --jq 'map(select(.status == "completed" and (.conclusion != "success" and .conclusion != "skipped"))) | first | .databaseId // ""'
+            )"
+
+            if [ -n "${failed_run}" ]; then
+              echo "amd64-image-build failed for ${HEAD_SHA}: ${failed_run}" >&2
+              exit 1
+            fi
+
+            if [ -z "${active_run}" ] && [ "${attempt}" -gt 5 ]; then
+              echo "No active or successful amd64-image-build run found for ${HEAD_SHA}" >&2
+              exit 1
+            fi
+
+            echo "No completed image build yet, attempt ${attempt}/180"
+            sleep 60
+          done
+
+          echo "Timed out waiting for amd64-image-build for ${HEAD_SHA}" >&2
+          exit 1
+
+      - name: Download amd64 image artifact
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ steps.build_run.outputs.run_id }}
+          pattern: joininbox-amd64-image-*
+          path: artifacts
+          merge-multiple: true
+
+      - name: Verify and decompress image
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          cd artifacts
+          sha256sum -c joininbox-amd64-debian.qcow2.gz.sha256
+          gzip -dk joininbox-amd64-debian.qcow2.gz
+          sha256sum -c joininbox-amd64-debian.qcow2.sha256
+
+      - name: Run image Bats tests
+        timeout-minutes: 30
+        run: ci/amd64/test.amd64-image-bats.sh "${GITHUB_WORKSPACE}/artifacts/joininbox-amd64-debian.qcow2"

--- a/.github/workflows/amd64-image-test.yml
+++ b/.github/workflows/amd64-image-test.yml
@@ -5,14 +5,6 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request:
-    branches: ["master"]
-    paths-ignore:
-      - '*.md'
-      - '.gitignore'
-      - 'images'
-      - 'ci/arm64-rpi/**'
-      - 'scripts/jam-remote'
   workflow_run:
     workflows: ["amd64-image-build"]
     types: [completed]
@@ -37,86 +29,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          repository: ${{ github.event.workflow_run.head_repository.full_name || github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha || github.ref }}
+          repository: ${{ github.event.workflow_run.head_repository.full_name || github.repository }}
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 
-      - name: Resolve amd64 image build run ID
-        id: build_run
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PROVIDED_RUN_ID: ${{ github.event.workflow_run.id || inputs.run_id }}
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha || github.sha }}
-        run: |
-          set -euo pipefail
-
-          if [ -n "${PROVIDED_RUN_ID}" ]; then
-            echo "run_id=${PROVIDED_RUN_ID}" >>"${GITHUB_OUTPUT}"
-            exit 0
-          fi
-
-          echo "Waiting for successful amd64-image-build run for ${HEAD_SHA}"
-          for attempt in {1..180}; do
-            active_run="$(
-              gh run list \
-                --repo "${GITHUB_REPOSITORY}" \
-                --workflow amd64-image-build.yml \
-                --commit "${HEAD_SHA}" \
-                --event pull_request \
-                --limit 20 \
-                --json databaseId,status,conclusion,createdAt \
-                --jq 'map(select(.status != "completed")) | first | .databaseId // ""'
-            )"
-
-            run_id="$(
-              gh run list \
-                --repo "${GITHUB_REPOSITORY}" \
-                --workflow amd64-image-build.yml \
-                --commit "${HEAD_SHA}" \
-                --event pull_request \
-                --limit 20 \
-                --json databaseId,status,conclusion,createdAt \
-                --jq 'map(select(.status == "completed" and .conclusion == "success")) | first | .databaseId // ""'
-            )"
-
-            if [ -n "${run_id}" ]; then
-              echo "run_id=${run_id}" >>"${GITHUB_OUTPUT}"
-              exit 0
-            fi
-
-            failed_run="$(
-              gh run list \
-                --repo "${GITHUB_REPOSITORY}" \
-                --workflow amd64-image-build.yml \
-                --commit "${HEAD_SHA}" \
-                --event pull_request \
-                --limit 20 \
-                --json databaseId,status,conclusion,createdAt \
-                --jq 'map(select(.status == "completed" and (.conclusion != "success" and .conclusion != "skipped"))) | first | .databaseId // ""'
-            )"
-
-            if [ -n "${failed_run}" ]; then
-              echo "amd64-image-build failed for ${HEAD_SHA}: ${failed_run}" >&2
-              exit 1
-            fi
-
-            if [ -z "${active_run}" ] && [ "${attempt}" -gt 5 ]; then
-              echo "No active or successful amd64-image-build run found for ${HEAD_SHA}" >&2
-              exit 1
-            fi
-
-            echo "No completed image build yet, attempt ${attempt}/180"
-            sleep 60
-          done
-
-          echo "Timed out waiting for amd64-image-build for ${HEAD_SHA}" >&2
-          exit 1
+      - name: Check out bats-core
+        uses: actions/checkout@v4
+        with:
+          repository: bats-core/bats-core
+          # bats-core v1.12.0
+          ref: 713504bc0224a19b3d7c7958c18dc07f64f54b44
+          path: .bats-core
+          persist-credentials: false
 
       - name: Download amd64 image artifact
         uses: actions/download-artifact@v4
         with:
           github-token: ${{ github.token }}
-          run-id: ${{ steps.build_run.outputs.run_id }}
+          run-id: ${{ github.event.workflow_run.id || inputs.run_id }}
           pattern: joininbox-amd64-image-*
           path: artifacts
           merge-multiple: true

--- a/.github/workflows/amd64-image-test.yml
+++ b/.github/workflows/amd64-image-test.yml
@@ -24,7 +24,7 @@ jobs:
     name: Run Bats against amd64 image artifact
     runs-on: ubuntu-22.04
     timeout-minutes: 240
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name != 'workflow_run' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_repository.full_name == github.repository) }}
 
     steps:
       - uses: actions/checkout@v4

--- a/FAQ.md
+++ b/FAQ.md
@@ -467,8 +467,8 @@ Bitcoin Core has deprecated BDB (Berkeley DB) wallets in favor of descriptor wal
 
 If you're upgrading from a previous version of JoininBox that used `wallet.dat`, follow these steps:
 
-1. **The migration notice will appear automatically**  
-   When you first use any wallet-related function after updating, JoininBox will detect the old `wallet.dat` and display a migration notice.
+1. **The migration notice will appear automatically on Bitcoin Core v30.0 and newer**
+   When you first use any wallet-related function after updating, JoininBox checks the connected Bitcoin Core version. On v30.0 and newer it switches the configured RPC wallet to `watch-only-descriptor-wallet`, detects the old `wallet.dat`, and displays a migration notice. Bitcoin Core v29.x and earlier continue using `wallet.dat` without starting the automatic migration.
 
 2. **Open each JoinMarket wallet**  
    Go to `WALLET` -> `DISPLAY` and open each of your JoinMarket wallets (`.jmdat` files) at least once. This imports the addresses into the new `watch-only-descriptor-wallet` in Bitcoin Core.
@@ -494,6 +494,7 @@ If you're upgrading from a previous version of JoininBox that used `wallet.dat`,
 ### Notes
 
 - The old `wallet.dat` is not deleted and remains in Bitcoin Core
+- Automatic migration only runs when the connected Bitcoin Core version is v30.0 or newer
 - You only need to perform this migration once
 - The migration notice will not appear again after you acknowledge it
 - If you have issues, you can reset the migration flag by removing `walletMigrationDone=true` from `/home/joinmarket/joinin.conf`

--- a/FAQ.md
+++ b/FAQ.md
@@ -463,6 +463,16 @@ Bitcoin Core has deprecated BDB (Berkeley DB) wallets in favor of descriptor wal
 - Have better performance and features
 - Are actively maintained and improved
 
+### How automatic migration works
+
+When `rpc_wallet_file` is still set to `wallet.dat`, JoininBox queries the connected Bitcoin Core node using RPC before changing the configuration:
+
+- Bitcoin Core v30.0 and newer: JoininBox atomically changes `rpc_wallet_file` to `watch-only-descriptor-wallet`, creates or loads that descriptor wallet, and displays the migration notice when the old `wallet.dat` is present.
+- Bitcoin Core v29.x and earlier: JoininBox keeps using `wallet.dat` and does not start automatic migration.
+- Version unavailable: JoininBox leaves `wallet.dat` configured rather than migrating without confirming compatibility.
+
+The migration does not rename, modify, or delete the old `wallet.dat`. It changes which Bitcoin Core wallet JoinMarket uses for watch-only address imports and transaction history.
+
 ### Migration steps for existing users
 
 If you're upgrading from a previous version of JoininBox that used `wallet.dat`, follow these steps:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ A minimalistic, security focused linux environment for JoinMarket with a termina
 * Start a pruned node from https://pruned.host4coins.net/blocks
 * JoininBox is part of the RaspiBlitz SERVICES
 
-**The addresses, transactions and balances of JoinMarket can be seen in the watch-only wallet of the connected node.**
+**The addresses, transactions and balances of JoinMarket can be seen in the watch-only-descriptor-wallet of the connected node.**
   * use your own or a trusted node
   * to protect privacy in case of physical access use disk encryption
 

--- a/ci/amd64/test.amd64-image-bats.sh
+++ b/ci/amd64/test.amd64-image-bats.sh
@@ -21,27 +21,69 @@ ssh_opts=(
   -p "${ssh_port}"
 )
 
-bios="${OVMF_BIOS:-}"
-if [ -z "${bios}" ]; then
+ovmf_code="${OVMF_CODE:-${OVMF_BIOS:-}}"
+ovmf_vars_template="${OVMF_VARS:-}"
+ovmf_vars="${RUNNER_TEMP:-/tmp}/joininbox-ovmf-vars.fd"
+qemu_firmware_args=()
+
+if [ -z "${ovmf_code}" ]; then
   for candidate in \
     /usr/share/OVMF/OVMF_CODE_4M.fd \
+    /usr/share/OVMF/OVMF_CODE_4M.secboot.fd \
+    /usr/share/OVMF/OVMF_CODE_4M.ms.fd \
     /usr/share/OVMF/OVMF_CODE.fd \
     /usr/share/OVMF/OVMF.fd \
     /usr/share/ovmf/OVMF_CODE_4M.fd \
+    /usr/share/ovmf/OVMF_CODE_4M.secboot.fd \
+    /usr/share/ovmf/OVMF_CODE_4M.ms.fd \
     /usr/share/ovmf/OVMF_CODE.fd \
     /usr/share/ovmf/OVMF.fd \
     OVMF.fd; do
     if [ -f "${candidate}" ]; then
-      bios="${candidate}"
+      ovmf_code="${candidate}"
       break
     fi
   done
 fi
 
-if [ -z "${bios}" ] || [ ! -f "${bios}" ]; then
-  echo "No OVMF BIOS file found. Set OVMF_BIOS to the firmware path." >&2
+if [ -z "${ovmf_code}" ] || [ ! -f "${ovmf_code}" ]; then
+  echo "No OVMF firmware found. Set OVMF_CODE or OVMF_BIOS to the firmware path." >&2
+  find /usr/share/OVMF /usr/share/ovmf -maxdepth 1 -type f -name '*.fd' -print 2>/dev/null || true
   exit 1
 fi
+
+case "${ovmf_code##*/}" in
+  *CODE*)
+    if [ -z "${ovmf_vars_template}" ]; then
+      for candidate in \
+        "${ovmf_code/CODE/VARS}" \
+        /usr/share/OVMF/OVMF_VARS_4M.fd \
+        /usr/share/OVMF/OVMF_VARS.fd \
+        /usr/share/ovmf/OVMF_VARS_4M.fd \
+        /usr/share/ovmf/OVMF_VARS.fd; do
+        if [ -f "${candidate}" ]; then
+          ovmf_vars_template="${candidate}"
+          break
+        fi
+      done
+    fi
+
+    if [ -z "${ovmf_vars_template}" ] || [ ! -f "${ovmf_vars_template}" ]; then
+      echo "No OVMF VARS template found for ${ovmf_code}. Set OVMF_VARS to the template path." >&2
+      find /usr/share/OVMF /usr/share/ovmf -maxdepth 1 -type f -name '*.fd' -print 2>/dev/null || true
+      exit 1
+    fi
+
+    cp "${ovmf_vars_template}" "${ovmf_vars}"
+    qemu_firmware_args=(
+      -drive "if=pflash,format=raw,readonly=on,file=${ovmf_code}"
+      -drive "if=pflash,format=raw,file=${ovmf_vars}"
+    )
+    ;;
+  *)
+    qemu_firmware_args=(-bios "${ovmf_code}")
+    ;;
+esac
 
 cleanup() {
   if [ -f "${qemu_pid_file}" ]; then
@@ -61,7 +103,7 @@ rm -f "${qemu_pid_file}"
 qemu-system-x86_64 \
   -m 2048 \
   -smp 2 \
-  -bios "${bios}" \
+  "${qemu_firmware_args[@]}" \
   -drive "file=${image},format=qcow2" \
   -netdev "user,id=net0,hostfwd=tcp:127.0.0.1:${ssh_port}-:22" \
   -device e1000,netdev=net0 \

--- a/ci/amd64/test.amd64-image-bats.sh
+++ b/ci/amd64/test.amd64-image-bats.sh
@@ -5,9 +5,15 @@ image="${1:-${GITHUB_WORKSPACE:-$(pwd)}/ci/amd64/builds/joininbox-amd64-debian-q
 ssh_port="${SSH_PORT:-2222}"
 ssh_password="${SSH_PASSWORD:-joininbox}"
 qemu_pid_file="${RUNNER_TEMP:-/tmp}/joininbox-qemu.pid"
+bats_core_dir="${BATS_CORE_DIR:-${GITHUB_WORKSPACE:-$(pwd)}/.bats-core}"
 
 if [ ! -f "${image}" ]; then
   echo "Missing image: ${image}" >&2
+  exit 1
+fi
+
+if [ ! -x "${bats_core_dir}/bin/bats" ]; then
+  echo "Missing bats-core checkout: ${bats_core_dir}" >&2
   exit 1
 fi
 
@@ -124,5 +130,9 @@ for attempt in {1..120}; do
   sleep 5
 done
 
+tar -C "${bats_core_dir}" -cf - . |
+  sshpass -p "${ssh_password}" ssh "${ssh_opts[@]}" joinmarket@127.0.0.1 \
+    "mkdir -p /tmp/bats-core && tar -C /tmp/bats-core -xf -"
+
 sshpass -p "${ssh_password}" ssh "${ssh_opts[@]}" joinmarket@127.0.0.1 \
-  "sudo apt-get update && sudo apt-get install -y bats && /home/joinmarket/joininbox/test/run-bats-local.sh"
+  "PATH=/tmp/bats-core/bin:\$PATH /home/joinmarket/joininbox/test/run-bats-local.sh"

--- a/ci/amd64/test.amd64-image-bats.sh
+++ b/ci/amd64/test.amd64-image-bats.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+image="${1:-${GITHUB_WORKSPACE:-$(pwd)}/ci/amd64/builds/joininbox-amd64-debian-qemu/joininbox-amd64-debian.qcow2}"
+ssh_port="${SSH_PORT:-2222}"
+ssh_password="${SSH_PASSWORD:-joininbox}"
+qemu_pid_file="${RUNNER_TEMP:-/tmp}/joininbox-qemu.pid"
+
+if [ ! -f "${image}" ]; then
+  echo "Missing image: ${image}" >&2
+  exit 1
+fi
+
+sudo apt-get update
+sudo apt-get install -y ovmf qemu-system-x86 sshpass
+
+ssh_opts=(
+  -o StrictHostKeyChecking=no
+  -o UserKnownHostsFile=/dev/null
+  -o ConnectTimeout=5
+  -p "${ssh_port}"
+)
+
+bios="${OVMF_BIOS:-}"
+if [ -z "${bios}" ]; then
+  for candidate in \
+    /usr/share/OVMF/OVMF_CODE_4M.fd \
+    /usr/share/OVMF/OVMF_CODE.fd \
+    /usr/share/OVMF/OVMF.fd \
+    /usr/share/ovmf/OVMF_CODE_4M.fd \
+    /usr/share/ovmf/OVMF_CODE.fd \
+    /usr/share/ovmf/OVMF.fd \
+    OVMF.fd; do
+    if [ -f "${candidate}" ]; then
+      bios="${candidate}"
+      break
+    fi
+  done
+fi
+
+if [ -z "${bios}" ] || [ ! -f "${bios}" ]; then
+  echo "No OVMF BIOS file found. Set OVMF_BIOS to the firmware path." >&2
+  exit 1
+fi
+
+cleanup() {
+  if [ -f "${qemu_pid_file}" ]; then
+    qemu_pid="$(cat "${qemu_pid_file}")"
+    if kill -0 "${qemu_pid}" 2>/dev/null; then
+      kill "${qemu_pid}" 2>/dev/null || true
+      timeout 30s tail --pid="${qemu_pid}" -f /dev/null 2>/dev/null ||
+        kill -9 "${qemu_pid}" 2>/dev/null ||
+        true
+    fi
+  fi
+}
+trap cleanup EXIT
+
+rm -f "${qemu_pid_file}"
+
+qemu-system-x86_64 \
+  -m 2048 \
+  -smp 2 \
+  -bios "${bios}" \
+  -drive "file=${image},format=qcow2" \
+  -netdev "user,id=net0,hostfwd=tcp:127.0.0.1:${ssh_port}-:22" \
+  -device e1000,netdev=net0 \
+  -display none \
+  -snapshot \
+  -pidfile "${qemu_pid_file}" \
+  -daemonize
+
+echo "Waiting for SSH in the booted image"
+for attempt in {1..120}; do
+  if sshpass -p "${ssh_password}" ssh "${ssh_opts[@]}" joinmarket@127.0.0.1 "true" 2>/dev/null; then
+    break
+  fi
+  if [ "${attempt}" -eq 120 ]; then
+    echo "Timed out waiting for SSH" >&2
+    exit 1
+  fi
+  sleep 5
+done
+
+sshpass -p "${ssh_password}" ssh "${ssh_opts[@]}" joinmarket@127.0.0.1 \
+  "sudo apt-get update && sudo apt-get install -y bats && /home/joinmarket/joininbox/test/run-bats-local.sh"

--- a/scripts/_functions.bitcoincore.sh
+++ b/scripts/_functions.bitcoincore.sh
@@ -379,7 +379,7 @@ function checkWalletMigration {
     return 0
   fi
 
-  getRPC
+  # RPC settings are already available from parent checkRPCwallet function
   tor=""
   if [ "$(echo "$rpc_host" | grep -c .onion)" -gt 0 ]; then
     tor="torsocks"

--- a/scripts/_functions.bitcoincore.sh
+++ b/scripts/_functions.bitcoincore.sh
@@ -345,7 +345,7 @@ function checkRPCwallet {
     #TODO rewrite customRPC to support multiple params
     $tor curl -sS --data-binary \
       '{"jsonrpc": "1.0", "id":"# Create the bitcoind wallet", "method": "createwallet", "params": {"wallet_name":"'"$rpc_wallet"'","descriptors":true,"disable_private_keys":true}}' \
-      http://$rpc_user:$rpc_pass@$rpc_host:$rpc_port/wallet/$rpc_wallet | jq .
+      http://$rpc_user:$rpc_pass@$rpc_host:$rpc_port/ | jq .
     echo
     walletFound=$(customRPC "# Check wallet" "listwallets" 2>$connectionOutput | grep -c "$rpc_wallet")
     if [ $walletFound -eq 0 ]; then

--- a/scripts/_functions.bitcoincore.sh
+++ b/scripts/_functions.bitcoincore.sh
@@ -321,9 +321,67 @@ function getRPC {
   fi
 }
 
+# getConnectedBitcoinCoreVersion - read the numeric version over node RPC
+function getConnectedBitcoinCoreVersion {
+  local tor=""
+  if [ "$(echo "$rpc_host" | grep -c .onion)" -gt 0 ]; then
+    tor="torsocks"
+  fi
+  $tor curl -sS --data-binary \
+    '{"jsonrpc": "1.0", "id":"get_bitcoin_core_version", "method": "getnetworkinfo", "params": []}' \
+    "http://$rpc_user:$rpc_pass@$rpc_host:$rpc_port/" 2>/dev/null |
+    jq -r '.result.version // empty' 2>/dev/null
+}
+
+# migrateLegacyRPCWalletConfig - switch the persisted JoinMarket RPC wallet
+# from the legacy wallet.dat name to the descriptor wallet used by JoininBox
+# when the connected Bitcoin Core version is v30.0 or newer
+function migrateLegacyRPCWalletConfig {
+  if [ "$rpc_wallet" != "wallet.dat" ]; then
+    return 0
+  fi
+
+  local bitcoinCoreVersion
+  bitcoinCoreVersion=$(getConnectedBitcoinCoreVersion)
+  if ! [[ "$bitcoinCoreVersion" =~ ^[0-9]+$ ]]; then
+    echo "# Could not determine the connected Bitcoin Core version; keeping wallet.dat"
+    return 0
+  fi
+  # Bitcoin Core's numeric version is 290200 for v29.2 and 300000 for v30.0.
+  if [ "$bitcoinCoreVersion" -lt 300000 ]; then
+    echo "# Connected Bitcoin Core is v29.x or earlier; keeping wallet.dat"
+    return 0
+  fi
+
+  echo "# Migrating the configured Bitcoin Core wallet from wallet.dat to watch-only-descriptor-wallet"
+  local migrationConfigOutput
+  if ! migrationConfigOutput=$(mktemp "${JMcfgPath}.XXXXXX"); then
+    echo "# Failed to create a temporary descriptor wallet configuration" >&2
+    return 1
+  fi
+  if ! sed \
+    "s/^rpc_wallet_file =.*/rpc_wallet_file = watch-only-descriptor-wallet/g" \
+    "$JMcfgPath" >"$migrationConfigOutput"; then
+    rm -f "$migrationConfigOutput"
+    echo "# Failed to prepare the descriptor wallet configuration" >&2
+    return 1
+  fi
+  if ! mv "$migrationConfigOutput" "$JMcfgPath"; then
+    rm -f "$migrationConfigOutput"
+    echo "# Failed to update the descriptor wallet configuration" >&2
+    return 1
+  fi
+  getRPC
+  if [ "$rpc_wallet" != "watch-only-descriptor-wallet" ]; then
+    echo "# Failed to select the descriptor wallet configuration" >&2
+    return 1
+  fi
+}
+
 # checkRPCwallet <wallet>
 function checkRPCwallet {
   getRPC
+  migrateLegacyRPCWalletConfig || return 1
   if [ $# -eq 0 ]; then
     rpc_wallet=$rpc_wallet
   else

--- a/scripts/_functions.sh
+++ b/scripts/_functions.sh
@@ -282,8 +282,8 @@ function generateJMconfig() {
     fi
     sed -i "s/^rpc_port =.*/rpc_port = $RPCPORT/g" $JMcfgPath
     echo  "# rpc_port = $RPCPORT"
-    sed -i "s/^rpc_wallet_file =.*/rpc_wallet_file = wallet.dat/g" $JMcfgPath
-    echo "# using the bitcoind wallet: wallet.dat"
+    sed -i "s/^rpc_wallet_file =.*/rpc_wallet_file = watch-only-descriptor-wallet/g" $JMcfgPath
+    echo "# using the bitcoind watch-only-descriptor-wallet"
     # set joinin.conf value
     /home/joinmarket/set.value.sh set network mainnet ${joininConfPath}
   fi

--- a/scripts/install.bitcoincore.sh
+++ b/scripts/install.bitcoincore.sh
@@ -5,13 +5,13 @@ source /home/joinmarket/_functions.sh
 
 # check connectedRemoteNode var in joinin.conf
 if ! grep -Eq "^connectedRemoteNode=" $joininConfPath; then
-  echo "connectedRemoteNode=off" >> $joininConfPath
+  echo "connectedRemoteNode=off" >>$joininConfPath
 fi
 
 if [ "$1" = "signetOn" ]; then
   installBitcoinCore
   installSignet
-  if [ "$connectedRemoteNode" = "on" ];then
+  if [ "$connectedRemoteNode" = "on" ]; then
     backupJMconf
   fi
   generateJMconfig
@@ -24,16 +24,16 @@ if [ "$1" = "signetOn" ]; then
     bitcoinUser="joinmarket"
     cliPath="/home/joinmarket/bitcoin/"
   fi
-  if [ ! -f /home/${bitcoinUser}/.bitcoin/signet/wallets/wallet.dat/wallet.dat ];then
-    echo "# Create wallet.dat for signet ..."
+  if [ ! -d /home/${bitcoinUser}/.bitcoin/signet/wallets/watch-only-descriptor-wallet ]; then
+    echo "# Create watch-only-descriptor-wallet for signet ..."
     sleep 10
-    sudo -u ${bitcoinUser} ${cliPath}/bitcoin-cli -signet -named createwallet wallet_name=wallet.dat descriptors=false
+    sudo -u ${bitcoinUser} ${cliPath}/bitcoin-cli -signet -named createwallet wallet_name=watch-only-descriptor-wallet descriptors=true disable_private_keys=true
   fi
 
 elif [ "$1" = "signetOff" ]; then
   removeSignetdService
-  isSignet=$(grep -c "network = signet" < $JMcfgPath)
-  if [ $isSignet -gt 0 ];then
+  isSignet=$(grep -c "network = signet" <$JMcfgPath)
+  if [ $isSignet -gt 0 ]; then
     echo "# Removing the joinmarket.cfg with signet settings"
     rm -f $JMcfgPath
   else

--- a/scripts/install.joinmarket.sh
+++ b/scripts/install.joinmarket.sh
@@ -122,13 +122,6 @@ range_argument install "install" "config" "update" "testPR" "commit"
 if [[ "${version}" == v* ]]; then
   curl -s "https://github.com/JoinMarket-Org/joinmarket-clientserver/release/tag/${version}" | grep -q "\"message\": \"Version not found\"" && error_msg "'There is no: https://github.com/JoinMarket-Org/joinmarket-clientserver/release/tag/${version}'"
 fi
-# Use tag if set, otherwise use commit hash
-: "${version:=${testedJMversion:-$testedJMcommit}}"
-# Only check GitHub releases if version looks like a tag (starts with 'v')
-if [[ "${version}" == v* ]]; then
-  curl -s "https://github.com/JoinMarket-Org/joinmarket-clientserver/release/tag/${version}" | grep -q "\"message\": \"Version not found\"" && error_msg "'There is no: https://github.com/JoinMarket-Org/joinmarket-clientserver/release/tag/${version}'"
-fi
-
 : "${qtgui:=false}"
 range_argument qtgui "0" "1" "false" "true"
 

--- a/scripts/install.joinmarket.sh
+++ b/scripts/install.joinmarket.sh
@@ -120,7 +120,7 @@ range_argument install "install" "config" "update" "testPR" "commit"
 : "${version:=${testedJMversion:-$testedJMcommit}}"
 # Only check GitHub releases if version looks like a tag (starts with 'v')
 if [[ "${version}" == v* ]]; then
-  curl -s "https://github.com/JoinMarket-Org/joinmarket-clientserver/release/tag/${version}" | grep -q "\"message\": \"Version not found\"" && error_msg "'There is no: https://github.com/JoinMarket-Org/joinmarket-clientserver/release/tag/${version}'"
+  curl -s "https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/${version}" | grep -q "\"message\": \"Version not found\"" && error_msg "'There is no: https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/${version}'"
 fi
 : "${qtgui:=false}"
 range_argument qtgui "0" "1" "false" "true"

--- a/scripts/install.joinmarket.sh
+++ b/scripts/install.joinmarket.sh
@@ -122,6 +122,12 @@ range_argument install "install" "config" "update" "testPR" "commit"
 if [[ "${version}" == v* ]]; then
   curl -s "https://github.com/JoinMarket-Org/joinmarket-clientserver/release/tag/${version}" | grep -q "\"message\": \"Version not found\"" && error_msg "'There is no: https://github.com/JoinMarket-Org/joinmarket-clientserver/release/tag/${version}'"
 fi
+# Use tag if set, otherwise use commit hash
+: "${version:=${testedJMversion:-$testedJMcommit}}"
+# Only check GitHub releases if version looks like a tag (starts with 'v')
+if [[ "${version}" == v* ]]; then
+  curl -s "https://github.com/JoinMarket-Org/joinmarket-clientserver/release/tag/${version}" | grep -q "\"message\": \"Version not found\"" && error_msg "'There is no: https://github.com/JoinMarket-Org/joinmarket-clientserver/release/tag/${version}'"
+fi
 
 : "${qtgui:=false}"
 range_argument qtgui "0" "1" "false" "true"

--- a/scripts/menu.wallet.sh
+++ b/scripts/menu.wallet.sh
@@ -194,7 +194,7 @@ Enter the new gap limit to be used" 16 60 2> "$gaplimit"
     echo
     /home/joinmarket/start.script.sh wallet-tool "$(cat $wallet)"|grep mixdepth|sed -n '1~2p'|awk '{print $3}'
     echo
-    echo "Import the master public keys to Specter Desktop or Electrum to create watch only wallets."
+    echo "Import the master public keys to Specter Desktop or Electrum to create watch-only wallets."
     echo
     echo "Press ENTER to return to the menu..."
     read key

--- a/scripts/standalone/_functions.standalone.sh
+++ b/scripts/standalone/_functions.standalone.sh
@@ -290,9 +290,9 @@ WantedBy=multi-user.target
   echo "# Monitor the bitcoind with: sudo tail -f /home/bitcoin/.bitcoin/mainnet/debug.log"
   echo
 
-  if [ ! -f /home/bitcoin/.bitcoin/mainnet/wallets/wallet.dat/wallet.dat ]; then
-    echo "# Create wallet.dat ..."
+  if [ ! -d /home/bitcoin/.bitcoin/wallets/watch-only-descriptor-wallet ]; then
+    echo "# Create watch-only-descriptor-wallet ..."
     sleep 10
-    sudo -u bitcoin /usr/local/bin/bitcoin-cli -named createwallet wallet_name=wallet.dat descriptors=false
+    sudo -u bitcoin /usr/local/bin/bitcoin-cli -named createwallet wallet_name=watch-only-descriptor-wallet descriptors=true disable_private_keys=true
   fi
 }

--- a/test/README.md
+++ b/test/README.md
@@ -20,14 +20,13 @@ mainnet, signet, or any existing Bitcoin Core state.
 The `amd64-image-test` workflow downloads a previously built
 `joininbox-amd64-image-*` artifact, verifies the compressed and raw checksums,
 decompresses a runner-local qcow2 copy, boots it with QEMU in snapshot mode,
-installs `bats` inside that temporary VM session, and runs the same suite from
-the JoininBox checkout inside the image.
+copies a pinned `bats-core` checkout into that temporary VM session, and runs
+the same suite from the JoininBox checkout inside the image. This avoids
+depending on the guest's configured APT repositories just to install test
+tooling.
 
-The test workflow has three entry points:
+The test workflow has two entry points:
 
-- `pull_request`: waits for the successful `amd64-image-build` run for the same
-  head commit, then tests that artifact. This makes the workflow usable while it
-  is still being introduced in a PR.
 - `workflow_run`: runs after a successful `amd64-image-build` once this workflow
   exists on the repository default branch.
 - `workflow_dispatch`: reruns against a specific build artifact by providing the

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,35 @@
+# JoininBox integration tests
+
+Run the local Bats suite with:
+
+```bash
+test/run-bats-local.sh
+```
+
+The descriptor wallet tests require:
+
+- `bats`
+- `bitcoind`
+- `bitcoin-cli`
+- `curl`
+- `jq`
+
+The suite starts its own temporary `bitcoind -regtest` datadir and does not use
+mainnet, signet, or any existing Bitcoin Core state.
+
+The `amd64-image-test` workflow downloads a previously built
+`joininbox-amd64-image-*` artifact, verifies the compressed and raw checksums,
+decompresses a runner-local qcow2 copy, boots it with QEMU in snapshot mode,
+installs `bats` inside that temporary VM session, and runs the same suite from
+the JoininBox checkout inside the image.
+
+The test workflow has three entry points:
+
+- `pull_request`: waits for the successful `amd64-image-build` run for the same
+  head commit, then tests that artifact. This makes the workflow usable while it
+  is still being introduced in a PR.
+- `workflow_run`: runs after a successful `amd64-image-build` once this workflow
+  exists on the repository default branch.
+- `workflow_dispatch`: reruns against a specific build artifact by providing the
+  `amd64-image-build` workflow run ID, as long as the artifact is still retained
+  by GitHub Actions.

--- a/test/bats/descriptor-wallet.bats
+++ b/test/bats/descriptor-wallet.bats
@@ -1,0 +1,159 @@
+#!/usr/bin/env bats
+
+root_dir="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+PATH="/home/joinmarket/bitcoin:/usr/local/bin:$PATH"
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    skip "$1 is required"
+  fi
+}
+
+setup() {
+  require_command bitcoind
+  require_command bitcoin-cli
+  require_command curl
+  require_command jq
+
+  rpc_user="joininbox"
+  rpc_pass="joininbox"
+  rpc_port="$((20000 + (RANDOM % 20000)))"
+  p2p_port="$((40000 + (RANDOM % 20000)))"
+  bitcoin_datadir="${BATS_TEST_TMPDIR}/bitcoin"
+  joinmarket_cfg="${BATS_TEST_TMPDIR}/joinmarket.cfg"
+  joinin_conf="${BATS_TEST_TMPDIR}/joinin.conf"
+
+  mkdir -p "$bitcoin_datadir"
+
+  bitcoind \
+    -regtest \
+    -datadir="$bitcoin_datadir" \
+    -server \
+    -daemonwait \
+    -rpcuser="$rpc_user" \
+    -rpcpassword="$rpc_pass" \
+    -rpcport="$rpc_port" \
+    -port="$p2p_port" \
+    -fallbackfee=0.0001
+
+  cat >"$joinmarket_cfg" <<EOF
+rpc_user = $rpc_user
+rpc_password = $rpc_pass
+rpc_host = 127.0.0.1
+rpc_port = $rpc_port
+rpc_wallet_file = watch-only-descriptor-wallet
+EOF
+  : >"$joinin_conf"
+}
+
+teardown() {
+  if [ -n "${bitcoin_datadir:-}" ] && [ -d "$bitcoin_datadir" ]; then
+    bitcoin-cli \
+      -regtest \
+      -datadir="$bitcoin_datadir" \
+      -rpcuser="$rpc_user" \
+      -rpcpassword="$rpc_pass" \
+      -rpcport="$rpc_port" \
+      stop >/dev/null 2>&1 || true
+  fi
+}
+
+load_joininbox_bitcoin_functions() {
+  # shellcheck source=scripts/_functions.bitcoincore.sh
+  # shellcheck disable=SC1091
+  source "$root_dir/scripts/_functions.bitcoincore.sh"
+  # shellcheck disable=SC2034
+  JMcfgPath="$joinmarket_cfg"
+  # shellcheck disable=SC2034
+  joininConfPath="$joinin_conf"
+
+  mktemp() {
+    if [ "${1:-}" = "-p" ] && [ "${2:-}" = "/dev/shm/" ]; then
+      command mktemp "${BATS_TEST_TMPDIR}/joininbox.XXXXXX"
+    else
+      command mktemp "$@"
+    fi
+  }
+}
+
+wallet_info() {
+  bitcoin-cli \
+    -regtest \
+    -datadir="$bitcoin_datadir" \
+    -rpcuser="$rpc_user" \
+    -rpcpassword="$rpc_pass" \
+    -rpcport="$rpc_port" \
+    -rpcwallet=watch-only-descriptor-wallet \
+    getwalletinfo
+}
+
+check_wallet_migration_with_enter() {
+  printf "\n" | checkWalletMigration
+}
+
+@test "checkRPCwallet creates the configured descriptor watch-only wallet" {
+  load_joininbox_bitcoin_functions
+
+  run checkRPCwallet
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"The wallet: watch-only-descriptor-wallet is present and loaded"* ]]
+
+  run wallet_info
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.descriptors' <<<"$output")" = "true" ]
+  [ "$(jq -r '.private_keys_enabled' <<<"$output")" = "false" ]
+  run grep -q "walletMigrationDone" "$joinin_conf"
+  [ "$status" -ne 0 ]
+}
+
+@test "customRPC uses the descriptor wallet RPC endpoint" {
+  bitcoin-cli \
+    -regtest \
+    -datadir="$bitcoin_datadir" \
+    -rpcuser="$rpc_user" \
+    -rpcpassword="$rpc_pass" \
+    -rpcport="$rpc_port" \
+    -named createwallet \
+    wallet_name=watch-only-descriptor-wallet \
+    descriptors=true \
+    disable_private_keys=true >/dev/null
+
+  load_joininbox_bitcoin_functions
+
+  run customRPC "# Wallet info" "getwalletinfo" ""
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"walletname": "watch-only-descriptor-wallet"'* ]]
+  [[ "$output" == *'"descriptors": true'* ]]
+  [[ "$output" == *'"private_keys_enabled": false'* ]]
+}
+
+@test "checkWalletMigration shows the notice once when wallet.dat exists" {
+  bitcoin-cli \
+    -regtest \
+    -datadir="$bitcoin_datadir" \
+    -rpcuser="$rpc_user" \
+    -rpcpassword="$rpc_pass" \
+    -rpcport="$rpc_port" \
+    -named createwallet \
+    wallet_name=wallet.dat \
+    descriptors=true \
+    disable_private_keys=true >/dev/null
+
+  load_joininbox_bitcoin_functions
+  # shellcheck disable=SC2034
+  rpc_host="127.0.0.1"
+  # shellcheck disable=SC2034
+  rpc_wallet="watch-only-descriptor-wallet"
+
+  run check_wallet_migration_with_enter
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"WALLET MIGRATION NOTICE"* ]]
+  grep -q "^walletMigrationDone=true$" "$joinin_conf"
+
+  run checkWalletMigration
+  [ "$status" -eq 0 ]
+  [ "$output" = "" ]
+}

--- a/test/bats/descriptor-wallet.bats
+++ b/test/bats/descriptor-wallet.bats
@@ -91,6 +91,10 @@ check_wallet_migration_with_enter() {
   printf "\n" | checkWalletMigration
 }
 
+check_rpc_wallet_with_enter() {
+  printf "\n" | checkRPCwallet
+}
+
 @test "checkRPCwallet creates the configured descriptor watch-only wallet" {
   load_joininbox_bitcoin_functions
 
@@ -127,6 +131,57 @@ check_wallet_migration_with_enter() {
   [[ "$output" == *'"walletname": "watch-only-descriptor-wallet"'* ]]
   [[ "$output" == *'"descriptors": true'* ]]
   [[ "$output" == *'"private_keys_enabled": false'* ]]
+}
+
+@test "checkRPCwallet migrates a persisted wallet.dat configuration on Bitcoin Core v30 or later" {
+  bitcoin-cli \
+    -regtest \
+    -datadir="$bitcoin_datadir" \
+    -rpcuser="$rpc_user" \
+    -rpcpassword="$rpc_pass" \
+    -rpcport="$rpc_port" \
+    -named createwallet \
+    wallet_name=wallet.dat \
+    descriptors=true \
+    disable_private_keys=true >/dev/null
+  sed \
+    "s/^rpc_wallet_file =.*/rpc_wallet_file = wallet.dat/" \
+    "$joinmarket_cfg" >"${joinmarket_cfg}.legacy"
+  mv "${joinmarket_cfg}.legacy" "$joinmarket_cfg"
+
+  load_joininbox_bitcoin_functions
+
+  run check_rpc_wallet_with_enter
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Migrating the configured Bitcoin Core wallet"* ]]
+  [[ "$output" == *"WALLET MIGRATION NOTICE"* ]]
+  grep -q "^rpc_wallet_file = watch-only-descriptor-wallet$" "$joinmarket_cfg"
+  grep -q "^walletMigrationDone=true$" "$joinin_conf"
+
+  run wallet_info
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.descriptors' <<<"$output")" = "true" ]
+  [ "$(jq -r '.private_keys_enabled' <<<"$output")" = "false" ]
+}
+
+@test "migrateLegacyRPCWalletConfig keeps wallet.dat on Bitcoin Core v29.2" {
+  sed \
+    "s/^rpc_wallet_file =.*/rpc_wallet_file = wallet.dat/" \
+    "$joinmarket_cfg" >"${joinmarket_cfg}.legacy"
+  mv "${joinmarket_cfg}.legacy" "$joinmarket_cfg"
+
+  load_joininbox_bitcoin_functions
+  getConnectedBitcoinCoreVersion() {
+    echo 290200
+  }
+  getRPC >/dev/null
+
+  run migrateLegacyRPCWalletConfig
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"v29.x or earlier; keeping wallet.dat"* ]]
+  grep -q "^rpc_wallet_file = wallet.dat$" "$joinmarket_cfg"
 }
 
 @test "checkWalletMigration shows the notice once when wallet.dat exists" {

--- a/test/run-bats-local.sh
+++ b/test/run-bats-local.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if ! command -v bats >/dev/null 2>&1; then
+  echo "bats is required. Install bats-core, then rerun this script." >&2
+  exit 127
+fi
+
+bats test/bats


### PR DESCRIPTION

### Bitcoin Core Descriptor Wallet Migration
- **Switch to descriptor wallets**: Replace legacy `wallet.dat` with `watch-only-descriptor-wallet` using `descriptors=true` and `disable_private_keys=true`
- **Remove deprecated RPC workaround**: Removed the `deprecatedrpc=create_bdb` configuration check since BDB wallets are no longer created
- **Automatic migration detection**: Added `checkWalletMigration` function that detects existing `wallet.dat` and guides users through the migration process with step-by-step instructions
- **Migration tracking**: Stores `walletMigrationDone=true` in `joinin.conf` to show migration notice only once
- **Updated all references**: Changed wallet name from `wallet.dat` to `watch-only-descriptor-wallet` across:
  - `_functions.bitcoincore.sh`
  - `_functions.sh`
  - `_functions.standalone.sh`
  - `install.bitcoincore.sh`
  - Documentation files (FAQ.md, README.md, release_notes.md, prepare_remote_node.md)

### CI/Build Infrastructure
- **Migrate Packer to HCL format**: Replace `joininbox-amd64-debian.json` with `build.amd64-debian.pkr.hcl`
- **Upgrade to Debian 13.3.0**: Updated base ISO from Debian 12.11.0 to 13.3.0
- **Add UEFI boot support**: New Packer configuration supports both UEFI and legacy BIOS boot modes
- **Modernize preseed configuration**: Replace old Debian 9 preseed with updated configuration for Debian 13
- **Install OVMF firmware**: Added `ovmf` package to enable UEFI boot in QEMU
- **Use `packer init`**: Build script now uses `packer init -upgrade` for automatic plugin management

### Documentation
- Updated wallet references in FAQ.md, README.md, release_notes.md
- **Added migration guide**: New FAQ section explaining the wallet migration process for existing users

## Migration Guide for Existing Users

Existing users with the legacy `wallet.dat` will see a migration notice on first run after updating. The steps are:

1. **Open each JoinMarket wallet** via `WALLET` -> `DISPLAY` to import addresses into the new descriptor wallet
2. **Run a blockchain rescan** via `WALLET` -> `RESCAN` with blockheight `481824` (or earlier if needed)
3. **Wait for rescan to complete** (can take several hours)

See the updated FAQ for detailed instructions.