### PR TITLE
fix(service): add memory and CPU limits to reduce OOM kills

### DIFF
--- a/scripts/start.service.sh
+++ b/scripts/start.service.sh
@@ -43,6 +43,18 @@ Type=simple
 TimeoutSec=infinity
 Restart=no
 
+# Memory limits (DoS / OOM protection)
+MemoryHigh=300M
+MemoryMax=512M
+MemorySwapMax=0
+
+# Reduce OOM kill priority (lower = less likely to be killed)
+OOMScoreAdjust=-500
+OOMPolicy=stop
+
+# CPU limit
+CPUQuota=80%
+
 # Hardening measures
 PrivateTmp=true
 ProtectSystem=full


### PR DESCRIPTION
Add some mitigation on the systemd service level to avoid the process being killed due to DoS attacks.