### PR TITLE
chore(standalone): bitcoin core update to v29.2

### DIFF
--- a/scripts/_functions.bitcoincore.sh
+++ b/scripts/_functions.bitcoincore.sh
@@ -9,7 +9,7 @@ joininConfPath="/home/joinmarket/joinin.conf"
 function downloadBitcoinCore() {
   # set version
   # https://bitcoincore.org/en/download/
-  bitcoinVersion="26.1"
+  bitcoinVersion="29.2"
 
   if bitcoin-cli --version | grep $bitcoinVersion >/dev/null; then
     echo "# Bitcoin Core $bitcoinVersion is already installed"


### PR DESCRIPTION
using the latest version still compatible with the legacy wallets