### PR TITLE
security: harden wallet credential temp files

### DIFF
--- a/.github/workflows/test-bats.yml
+++ b/.github/workflows/test-bats.yml
@@ -1,0 +1,30 @@
+name: Test bats
+
+concurrency:
+  group: test-bats-${{ github.head_ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  workflow_dispatch:
+
+jobs:
+  bats:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install bats
+        run: |
+          git clone --depth 1 --branch v1.11.0 \
+            https://github.com/bats-core/bats-core.git /tmp/bats-core
+          sudo ln -sf /tmp/bats-core/bin/bats /usr/local/bin/bats
+          bats --version
+
+      # bats -r picks up every *.bats file under tests/ - new test files are
+      # discovered automatically, no workflow change needed.
+      - name: Run the bats test suite
+        run: bats -r tests

--- a/build_joininbox.sh
+++ b/build_joininbox.sh
@@ -433,7 +433,8 @@ else
   command="bash /home/joinmarket/joininbox/scripts/verify.git.sh \
     ${PGPsigner} ${PGPpubkeyLink} ${PGPpubkeyFingerprint}"
   echo "running: ${command}"
-  chmod 777 /dev/shm
+  # /dev/shm must retain the sticky bit so users cannot remove each other's files.
+  chmod 1777 /dev/shm
   sudo -u joinmarket ${command} || exit 1
 fi
 

--- a/scripts/_functions.menu.sh
+++ b/scripts/_functions.menu.sh
@@ -36,10 +36,10 @@ function menu_MAKER() {
     /home/joinmarket/menu.yg.sh
     return 1
   fi
-  # get password (creates /dev/shm/.pw)
+  # get password (creates the mktemp'd wallet password file)
   passwordToFile
   echo "# Using the wallet: $walletCanonical"
-  if /home/joinmarket/start.service.sh yg-privacyenhanced "$walletCanonical"; then
+  if /home/joinmarket/start.service.sh yg-privacyenhanced "$walletCanonical" "$walletPasswordFile"; then
     echo
     echo "# started the Yield Generator in the background"
     echo
@@ -53,9 +53,9 @@ function menu_MAKER() {
     echo
     echo "# ERROR: the Yield Generator failed to start (exit code $startStatus)"
     # remove the password temp file left behind by the failed start
-    if [ -f /dev/shm/.pw ]; then
-      shred -uvz /dev/shm/.pw
-      echo "# Removed the password temp file /dev/shm/.pw"
+    if [ -f "$walletPasswordFile" ]; then
+      shred -uvz "$walletPasswordFile"
+      echo "# Removed the password temp file $walletPasswordFile"
     fi
     echo "# Press ENTER to return to the menu."
     read key

--- a/scripts/_functions.sh
+++ b/scripts/_functions.sh
@@ -119,7 +119,9 @@ function passwordToFile() {
     return 1
   }
   chmod 600 -- "$data" "$walletPasswordFile"
-  trap 'rm -f -- "$data" "$walletPasswordFile"' EXIT
+  # keep parity with the chooseWallet EXIT trap so the $wallet temp file is
+  # still cleaned up on shell exit after passwordToFile replaces the trap
+  trap 'rm -f -- "$data" "$walletPasswordFile" "$wallet"' EXIT
   dialog --clear \
    --backtitle "Enter password" \
    --title "Enter password" \

--- a/scripts/_functions.sh
+++ b/scripts/_functions.sh
@@ -110,10 +110,16 @@ function waitKeyOnExit1() {
 }
 
 function passwordToFile() {
-  # write password into a file (to be shredded)
+  # Create an unpredictable, user-only credential file in RAM.
   # get password
-  trap 'rm -f "$data"' EXIT
-  data=$(mktemp -p /dev/shm/)
+  local data
+  data=$(mktemp /dev/shm/joininbox-dialog.XXXXXX) || return 1
+  walletPasswordFile=$(mktemp /dev/shm/joininbox-wallet-password.XXXXXX) || {
+    rm -f -- "$data"
+    return 1
+  }
+  chmod 600 -- "$data" "$walletPasswordFile"
+  trap 'rm -f -- "$data" "$walletPasswordFile"' EXIT
   dialog --clear \
    --backtitle "Enter password" \
    --title "Enter password" \
@@ -123,23 +129,17 @@ function passwordToFile() {
   pressed=$?
   case $pressed in
     0)
-      touch /dev/shm/.pw
-      chmod 600 /dev/shm/.pw
-      tee /dev/shm/.pw 1>/dev/null < "$data"
-      shred "$data"
+      tee "$walletPasswordFile" 1>/dev/null < "$data"
+      rm -f -- "$data"
       ;;
     1)
-      shred "$data"
-      shred "$wallet"
-      shred -uvz /dev/shm/.pw
+      rm -f -- "$data" "$wallet" "$walletPasswordFile"
       echo "# Cancelled"
       exit 1
       ;;
     255)
-      shred "$data"
-      shred "$wallet"
-      shred -uvz /dev/shm/.pw
       [ -s "$data" ] &&  cat "$data" || echo "# ESC pressed."
+      rm -f -- "$data" "$wallet" "$walletPasswordFile"
       exit 1
       ;;
   esac
@@ -190,7 +190,7 @@ function chooseWallet() {
 # Validates a systemd service name and wallet input for start.service.sh.
 # Prints the canonical wallet path on stdout when valid.
 # Returns 1 (message on stderr) when the input is rejected.
-# Used to reject bad input BEFORE any credential file (/dev/shm/.pw) is created.
+# Used to reject bad input BEFORE any credential file (the wallet password temp file) is created.
 function validateServiceArgs() {
   local script="$1"
   local walletInput="$2"

--- a/scripts/start.service.sh
+++ b/scripts/start.service.sh
@@ -5,9 +5,26 @@ sourceConf /home/joinmarket/joinin.conf
 
 script="$1"
 walletInput="$2"
+passwordFile="$3"
+
+if [ ! -f "$passwordFile" ] || [ -L "$passwordFile" ]; then
+  echo "# Invalid wallet password file"
+  exit 1
+fi
+case "$passwordFile" in
+  /dev/shm/joininbox-wallet-password.*) ;;
+  *)
+    echo "# Wallet password file is outside the allowed runtime path"
+    exit 1
+    ;;
+esac
+if [ "$(stat -c '%u:%a' -- "$passwordFile")" != "$(id -u):600" ]; then
+  echo "# Wallet password file has an unsafe owner or mode"
+  exit 1
+fi
 
 # Validate and canonicalize ALL inputs at the very top,
-# before anything touches credential files (e.g. /dev/shm/.pw)
+# before anything touches credential files (the wallet password temp file)
 # or makes any system changes.
 wallet=$(validateServiceArgs "$script" "$walletInput") || exit 1
 
@@ -19,7 +36,7 @@ else
   tor=""
 fi
 
-startScript="cat /dev/shm/.pw | $tor python $script.py $wallet \
+startScript="cat '$passwordFile' | $tor python $script.py '$wallet' \
 --wallet-password-stdin"
 # display
 echo
@@ -76,4 +93,4 @@ echo
 
 sleep 5
 # delete password once used
-shred -uvz /dev/shm/.pw
+rm -f -- "$passwordFile"

--- a/scripts/start.service.sh
+++ b/scripts/start.service.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Usage: start.service.sh <script> <wallet> <passwordFile>
+# (the passwordFile argument was added when the wallet password moved from
+# /dev/shm/.pw to a per-run file; the old two-argument form is no longer valid)
 source /home/joinmarket/_functions.sh
 sourceConf /home/joinmarket/joinin.conf
 
@@ -15,6 +18,15 @@ case "$passwordFile" in
   /dev/shm/joininbox-wallet-password.*) ;;
   *)
     echo "# Wallet password file is outside the allowed runtime path"
+    exit 1
+    ;;
+esac
+# the suffix after the allowed prefix must be a plain filename
+# (no '/', no '..', so path traversal cannot pass the glob)
+passwordFileName="${passwordFile#/dev/shm/joininbox-wallet-password.}"
+case "$passwordFileName" in
+  ""|*..*|*/*)
+    echo "# Wallet password file name is invalid"
     exit 1
     ;;
 esac
@@ -88,7 +100,7 @@ sudo systemctl enable $script
 sudo systemctl start $script
 
 echo
-echo "# Shredding the password once used..."
+echo "# Deleting the password file once used..."
 echo
 
 sleep 5

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,45 @@
+# JoininBox tests
+
+## bats suite
+
+Shell tests using [bats-core](https://github.com/bats-core/bats-core).
+They run in GitHub Actions (`.github/workflows/test-bats.yml`) on every push
+to master and every pull request. `bats -r tests` discovers every `*.bats`
+file recursively - **to add tests, just drop a new `.bats` file here**, no CI
+change needed.
+
+Current coverage:
+- `start.service.bats` - the wallet password file validation in
+  `start.service.sh` (missing/symlink/outside-path/traversal/bad-mode
+  rejection, validation order, password over stdin, deletion after use)
+- `password-to-file.bats` - `passwordToFile` in `scripts/_functions.sh`
+  (unpredictable per-run file, mode 600, EXIT-trap cleanup, cancel/ESC paths)
+
+Shared environment setup lives in `helpers/joininbox-env.bash` - `load` it
+from new test files to get a minimal `/home/joinmarket` prepared.
+
+### Run locally
+
+```
+git clone --depth 1 https://github.com/bats-core/bats-core /tmp/bats-core
+/tmp/bats-core/bin/bats -r tests
+```
+
+The suite needs to create `/home/joinmarket` (uses sudo; passwordless on CI
+runners). On a machine without passwordless sudo run it inside a user
+namespace with a bind-mounted fake home:
+
+```
+mkdir -p /tmp/jm-fakehome /tmp/fakebin
+printf '#!/bin/bash\nexec "$@"\n' > /tmp/fakebin/sudo && chmod +x /tmp/fakebin/sudo
+unshare -rm bash -c '
+  mount --bind /tmp/jm-fakehome /home/joinmarket &&
+  export PATH="/tmp/fakebin:/tmp/bats-core/bin:$PATH" &&
+  cd '"$(pwd)"' && bats -r tests'
+```
+
+## Other tests
+
+- `test-prepare-release.sh` (on the first-boot-credentials branch) - mock-based
+  regression test for `prepare.release.sh`, no bats required:
+  `bash tests/test-prepare-release.sh`

--- a/tests/helpers/joininbox-env.bash
+++ b/tests/helpers/joininbox-env.bash
@@ -1,0 +1,36 @@
+# Shared environment for the joininbox bats tests.
+# Prepares a minimal /home/joinmarket so the real scripts can be sourced and
+# executed: the scripts hardcode /home/joinmarket paths and source
+# _functions.sh + the joinin.conf config at load time.
+#
+# On CI runners sudo is passwordless. Locally the suite can be run inside a
+# user namespace with a bind-mounted /home/joinmarket (see tests/README.md).
+
+JM_HOME="/home/joinmarket"
+TEST_WALLET="$JM_HOME/.joinmarket/wallets/validator-test.jmdat"
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+
+joininbox_setup_file() {
+  if [ ! -d "$JM_HOME" ]; then
+    sudo mkdir -p "$JM_HOME"
+    sudo touch "$JM_HOME/.bats-created"
+  fi
+  sudo cp "$REPO_ROOT/scripts/_functions.sh" "$JM_HOME/"
+  sudo cp "$REPO_ROOT/scripts/_functions.menu.sh" "$JM_HOME/"
+  sudo cp "$REPO_ROOT/scripts/_functions.bitcoincore.sh" "$JM_HOME/"
+  sudo mkdir -p "$JM_HOME/.joinmarket/wallets"
+  printf 'RPCoverTor=off\nrunBehindTor=off\n' | sudo tee "$JM_HOME/joinin.conf" >/dev/null
+  sudo touch "$TEST_WALLET"
+}
+
+joininbox_teardown_file() {
+  if [ -f "$JM_HOME/.bats-created" ]; then
+    # the directory was created by the test suite - remove it whole
+    sudo rm -rf "$JM_HOME"
+  else
+    # pre-existing directory - only remove what the suite added
+    sudo rm -f "$JM_HOME/_functions.sh" "$JM_HOME/_functions.menu.sh" \
+      "$JM_HOME/_functions.bitcoincore.sh" "$JM_HOME/joinin.conf" "$TEST_WALLET"
+    sudo rm -rf "$JM_HOME/.joinmarket"
+  fi
+}

--- a/tests/helpers/passwordToFile-harness.sh
+++ b/tests/helpers/passwordToFile-harness.sh
@@ -5,7 +5,7 @@
 # by passwordToFile must remove the file.
 # stdout must stay clean except for the final path - keep git noise on stderr.
 cd / || exit 1
-source /home/joinmarket/_functions.sh
+source /home/joinmarket/_functions.sh || true
 wallet="$1"
 : >"$wallet"
 passwordToFile

--- a/tests/helpers/passwordToFile-harness.sh
+++ b/tests/helpers/passwordToFile-harness.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Harness for the passwordToFile EXIT-trap test: sources the functions, runs
+# passwordToFile with a mocked dialog and prints the created
+# walletPasswordFile path. When this process exits, the EXIT trap installed
+# by passwordToFile must remove the file.
+# stdout must stay clean except for the final path - keep git noise on stderr.
+cd / || exit 1
+source /home/joinmarket/_functions.sh
+wallet="$1"
+: >"$wallet"
+passwordToFile
+printf '%s\n' "$walletPasswordFile"

--- a/tests/password-to-file.bats
+++ b/tests/password-to-file.bats
@@ -2,6 +2,9 @@
 # Tests for passwordToFile (scripts/_functions.sh): the wallet password goes
 # to an unpredictable, caller-owned, mode-600 file under /dev/shm - never to
 # the old fixed /dev/shm/.pw path - and is cleaned up on exit or cancel.
+#
+# Note: the suite must also pass from a tagless shallow checkout (CI), where
+# the git describe in _functions.sh fails - the source guard above covers it.
 
 load helpers/joininbox-env
 
@@ -28,7 +31,10 @@ EOF
   export PATH="$MOCK_BIN:$PATH"
   export DIALOG_PASSWORD="bats-secret-123"
   export DIALOG_EXIT=0
-  source /home/joinmarket/_functions.sh
+  # '|| true': the version-detection block at the top of _functions.sh runs
+  # git describe which fails (128) on a tagless/shallow checkout; without the
+  # guard bats' errexit would abort the source before the function definitions
+  source /home/joinmarket/_functions.sh || true
 }
 
 teardown() {

--- a/tests/password-to-file.bats
+++ b/tests/password-to-file.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+# Tests for passwordToFile (scripts/_functions.sh): the wallet password goes
+# to an unpredictable, caller-owned, mode-600 file under /dev/shm - never to
+# the old fixed /dev/shm/.pw path - and is cleaned up on exit or cancel.
+
+load helpers/joininbox-env
+
+setup_file() {
+  joininbox_setup_file
+}
+
+teardown_file() {
+  joininbox_teardown_file
+}
+
+setup() {
+  TEST_TMP="$(mktemp -d)"
+  MOCK_BIN="$TEST_TMP/mockbin"
+  mkdir -p "$MOCK_BIN"
+  # dialog mock: --passwordbox writes the entered password to stderr
+  cat >"$MOCK_BIN/dialog" <<'EOF'
+#!/bin/bash
+printf '%s' "${DIALOG_PASSWORD:-}" >&2
+exit "${DIALOG_EXIT:-0}"
+EOF
+  chmod +x "$MOCK_BIN/dialog"
+  export MOCK_BIN
+  export PATH="$MOCK_BIN:$PATH"
+  export DIALOG_PASSWORD="bats-secret-123"
+  export DIALOG_EXIT=0
+  source /home/joinmarket/_functions.sh
+}
+
+teardown() {
+  rm -rf "$TEST_TMP"
+}
+
+@test "creates the password file under the joininbox prefix with mode 600 and the entered content" {
+  wallet="$TEST_TMP/wallet.jmdat"
+  : >"$wallet"
+  passwordToFile
+  [[ "$walletPasswordFile" == /dev/shm/joininbox-wallet-password.* ]]
+  [ -f "$walletPasswordFile" ]
+  [ "$(stat -c '%a' -- "$walletPasswordFile")" = "600" ]
+  [ "$(stat -c '%u' -- "$walletPasswordFile")" = "$(id -u)" ]
+  [ "$(cat "$walletPasswordFile")" = "bats-secret-123" ]
+  # the old fixed path is not used
+  [ ! -e /dev/shm/.pw ]
+  rm -f "$walletPasswordFile"
+}
+
+@test "uses a fresh unpredictable file name on each call" {
+  wallet="$TEST_TMP/w1.jmdat"
+  : >"$wallet"
+  passwordToFile
+  first="$walletPasswordFile"
+  wallet="$TEST_TMP/w2.jmdat"
+  : >"$wallet"
+  passwordToFile
+  second="$walletPasswordFile"
+  [ "$first" != "$second" ]
+  [[ "$first" == /dev/shm/joininbox-wallet-password.* ]]
+  [[ "$second" == /dev/shm/joininbox-wallet-password.* ]]
+  rm -f "$first" "$second"
+}
+
+@test "removes the password file when the shell exits (EXIT trap)" {
+  f="$(DIALOG_PASSWORD=x bash "$REPO_ROOT/tests/helpers/passwordToFile-harness.sh" "$TEST_TMP/w.jmdat")"
+  [[ "$f" == /dev/shm/joininbox-wallet-password.* ]]
+  # the harness has exited by now, so the trap must have removed the file
+  [ ! -e "$f" ]
+}
+
+@test "cancel removes the credential files and exits 1" {
+  wallet="$TEST_TMP/w.jmdat"
+  : >"$wallet"
+  export DIALOG_EXIT=1
+  run passwordToFile
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Cancelled"* ]]
+  [ ! -e "$wallet" ]
+}
+
+@test "ESC removes the credential files and exits 1" {
+  wallet="$TEST_TMP/w.jmdat"
+  : >"$wallet"
+  export DIALOG_EXIT=255
+  run passwordToFile
+  [ "$status" -eq 1 ]
+  [ ! -e "$wallet" ]
+}

--- a/tests/start.service.bats
+++ b/tests/start.service.bats
@@ -1,0 +1,114 @@
+#!/usr/bin/env bats
+# Tests for the credential-file handling in start.service.sh:
+# the wallet password is passed via a per-run, caller-owned, mode-600 file
+# under /dev/shm/joininbox-wallet-password.* and is validated before any use.
+
+load helpers/joininbox-env
+
+SCRIPT="$REPO_ROOT/scripts/start.service.sh"
+
+setup_file() {
+  joininbox_setup_file
+}
+
+teardown_file() {
+  joininbox_teardown_file
+}
+
+setup() {
+  TEST_TMP="$(mktemp -d)"
+  MOCK_BIN="$TEST_TMP/mockbin"
+  mkdir -p "$MOCK_BIN"
+  export MOCK_BIN
+}
+
+teardown() {
+  rm -rf "$TEST_TMP"
+  rm -rf /dev/shm/joininbox-wallet-password.bats-trav.d
+  rm -f /dev/shm/joininbox-wallet-password.bats* /dev/shm/joininbox-pw-traversal-target
+}
+
+# create a valid password file: right prefix, caller-owned, mode 600
+make_pwfile() {
+  local f
+  f="$(mktemp /dev/shm/joininbox-wallet-password.bats.XXXXXX)"
+  printf 'bats-secret-password' >"$f"
+  chmod 600 "$f"
+  printf '%s\n' "$f"
+}
+
+# invoke via bash explicitly: works regardless of the exec bit or a noexec mount
+@test "rejects a missing password file" {
+  run bash "$SCRIPT" yg-privacyenhanced "$TEST_WALLET" /dev/shm/joininbox-wallet-password.bats-does-not-exist
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Invalid wallet password file"* ]]
+}
+
+@test "rejects a symlinked password file" {
+  target="$(make_pwfile)"
+  link=/dev/shm/joininbox-wallet-password.bats-link
+  ln -sf "$target" "$link"
+  run bash "$SCRIPT" yg-privacyenhanced "$TEST_WALLET" "$link"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Invalid wallet password file"* ]]
+}
+
+@test "rejects a password file outside the allowed runtime path" {
+  outside="$TEST_TMP/pw"
+  printf 'x' >"$outside"
+  chmod 600 "$outside"
+  run bash "$SCRIPT" yg-privacyenhanced "$TEST_WALLET" "$outside"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"outside the allowed runtime path"* ]]
+}
+
+@test "rejects path traversal in the password file name" {
+  target=/dev/shm/joininbox-pw-traversal-target
+  printf 'x' >"$target"
+  chmod 600 "$target"
+  travdir=/dev/shm/joininbox-wallet-password.bats-trav.d
+  mkdir -p "$travdir"
+  run bash "$SCRIPT" yg-privacyenhanced "$TEST_WALLET" "$travdir/../joininbox-pw-traversal-target"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"file name is invalid"* ]]
+}
+
+@test "rejects a password file with unsafe owner or mode" {
+  pwfile="$(make_pwfile)"
+  chmod 644 "$pwfile"
+  run bash "$SCRIPT" yg-privacyenhanced "$TEST_WALLET" "$pwfile"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"unsafe owner or mode"* ]]
+}
+
+@test "validates the password file before the service arguments" {
+  pwfile="$(make_pwfile)"
+  run bash "$SCRIPT" not-a-real-service "$TEST_WALLET" "$pwfile"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Refusing unsupported service"* ]]
+}
+
+@test "passes the password over stdin, keeps it out of the unit and deletes the file after use" {
+  # mock sudo: capture the generated unit file and log the systemctl calls
+  cat >"$MOCK_BIN/sudo" <<'EOF'
+#!/bin/bash
+echo "sudo $*" >>"$MOCK_BIN/sudo.log"
+if [ "$1" = "tee" ]; then
+  cat >"$MOCK_BIN/unit.out"
+fi
+exit 0
+EOF
+  chmod +x "$MOCK_BIN/sudo"
+  pwfile="$(make_pwfile)"
+  export PATH="$MOCK_BIN:$PATH"
+  run bash "$SCRIPT" yg-privacyenhanced "$TEST_WALLET" "$pwfile"
+  [ "$status" -eq 0 ]
+  grep -q "systemctl enable yg-privacyenhanced" "$MOCK_BIN/sudo.log"
+  # the unit reads the password file over stdin ...
+  grep -q -- "--wallet-password-stdin" "$MOCK_BIN/unit.out"
+  grep -q "cat '$pwfile'" "$MOCK_BIN/unit.out"
+  # ... and never contains the password itself
+  ! grep -q "bats-secret-password" "$MOCK_BIN/unit.out"
+  # the password file is deleted once used
+  [ ! -e "$pwfile" ]
+}


### PR DESCRIPTION
## Summary

- preserve the sticky bit on `/dev/shm` instead of changing it to mode `0777`
- replace the shared, predictable `/dev/shm/.pw` wallet credential with an unpredictable `mktemp` file
- pass the credential path explicitly to the service launcher
- reject symlinks, unexpected paths, owners, and modes before consuming the credential
- quote the wallet path and unlink temporary credentials promptly

This implements the temporary wallet credential recommendations from #186 without changing the JoinMarket password-stdin interface.

## Security impact

The old global filename could be pre-created or replaced by another local user, and removing the sticky bit from `/dev/shm` allowed users to remove each other's files. The new credential is created atomically with an unpredictable name, mode `0600`, checked immediately before use, and cleaned up through an EXIT trap and after service startup.

## Tests

- `bash -n` on all four changed shell scripts
- verified no remaining `/dev/shm/.pw` or `chmod 777 /dev/shm` references
- `git diff --check`
