### PR TITLE
security: validate and atomically install Tor config

### DIFF
--- a/scripts/install.hiddenservice.sh
+++ b/scripts/install.hiddenservice.sh
@@ -70,8 +70,11 @@ installTorrc() {
 generateTorrcCandidate() {
   service="$1"
   candidate="$2"
+  # the stage file is root-owned (sudo mktemp), so the write must stay
+  # inside the privileged pipeline - a plain shell redirect would be opened
+  # by the unprivileged caller and fail with EACCES
   stage=$(sudo mktemp) || exit 1
-  if ! sudo sed "/# Hidden Service for ${service}/,/^\s*$/{d}" /etc/tor/torrc > "$stage"; then
+  if ! sudo sed "/# Hidden Service for ${service}/,/^\s*$/{d}" /etc/tor/torrc | sudo tee "$stage" >/dev/null; then
     echo "ERROR: failed to read/process /etc/tor/torrc" >&2
     sudo rm -f -- "$stage"
     exit 1

--- a/scripts/install.hiddenservice.sh
+++ b/scripts/install.hiddenservice.sh
@@ -15,38 +15,65 @@ fi
 source /home/joinmarket/_functions.sh
 sourceConf /home/joinmarket/joinin.conf
 
+validateService() {
+  case "$1" in
+    ''|*[!A-Za-z0-9_-]*)
+      echo "ERROR: invalid service name: $1" >&2
+      exit 1
+      ;;
+  esac
+}
+
+validatePort() {
+  case "$1" in
+    ''|*[!0-9]*)
+      echo "ERROR: invalid port: $1" >&2
+      exit 1
+      ;;
+  esac
+  if [ "$1" -lt 1 ] || [ "$1" -gt 65535 ]; then
+    echo "ERROR: port outside the range 1-65535: $1" >&2
+    exit 1
+  fi
+}
+
+# Install a candidate torrc only after Tor accepts it. The temporary file lives
+# next to torrc so the final rename is atomic and remains root-owned.
+installTorrc() {
+  candidate="$1"
+  sudo chmod 644 "$candidate"
+  sudo chown root:root "$candidate"
+  if ! sudo tor --verify-config -f "$candidate"; then
+    echo "ERROR: Tor rejected the generated configuration" >&2
+    sudo rm -f -- "$candidate"
+    exit 1
+  fi
+  sudo mv -f -- "$candidate" /etc/tor/torrc
+}
+
 # delete a hidden service
 if [ "$1" == "off" ]; then
 
   service="$2"
-  if [ ${#service} -eq 0 ]; then
-    echo "ERROR: service name is missing"
-    exit 1
-  fi
+  validateService "$service"
 
-  # remove service paragraph
-  sudo sed -i "/# Hidden Service for ${service}/,/^\s*$/{d}" /etc/tor/torrc
-
-  # remove double empty lines
-  sudo cp /etc/tor/torrc /home/joinmarket/tmp
-  sudo chmod 777 /home/joinmarket/tmp
-  sudo awk 'NF > 0 {blank=0} NF == 0 {blank++} blank < 2' /etc/tor/torrc > /home/joinmarket/tmp
-  sudo mv /home/joinmarket/tmp /etc/tor/torrc
-  sudo chmod 644 /etc/tor/torrc
-  sudo chown bitcoin:bitcoin /etc/tor/torrc
+  candidate=$(sudo mktemp /etc/tor/torrc.joininbox.XXXXXX) || exit 1
+  trap 'sudo rm -f -- "$candidate"' EXIT
+  sudo sed "/# Hidden Service for ${service}/,/^\s*$/{d}" /etc/tor/torrc | \
+    awk 'NF > 0 {blank=0} NF == 0 {blank++} blank < 2' | \
+    sudo tee "$candidate" >/dev/null || exit 1
+  installTorrc "$candidate"
+  trap - EXIT
 
   echo "# OK service is removed - reloading Tor ..."
-  sudo pkill -sighup tor
+  sudo systemctl reload tor
   sleep 5
   echo "# Done"
   exit 0
 fi
 
 service="$1"
-if [ ${#service} -eq 0 ]; then
-  echo "ERROR: service name is missing"
-  exit 1
-fi
+validateService "$service"
 
 toPort="$2"
 if [ ${#toPort} -eq 0 ]; then
@@ -55,10 +82,8 @@ if [ ${#toPort} -eq 0 ]; then
 fi
 
 fromPort="$3"
-if [ ${#fromPort} -eq 0 ]; then
-  echo "ERROR: the port to forward from is missing"
-  exit 1
-fi
+validatePort "$toPort"
+validatePort "$fromPort"
 
 # not mandatory
 toPort2="$4"
@@ -70,6 +95,8 @@ if [ ${#toPort2} -gt 0 ]; then
     echo "ERROR: the second port to forward from is missing"
     exit 1
   fi
+  validatePort "$toPort2"
+  validatePort "$fromPort2"
 fi
 
 checkDirEntry=$(grep -c "HiddenServiceDir" < /home/joinmarket/joinin.conf)
@@ -84,33 +111,34 @@ fi
 
 if [ "${runBehindTor}" = "on" ]; then
 
-  # delete any old entry for that service
-  sudo sed -i "/# Hidden Service for ${service}/,/^\s*$/{d}" /etc/tor/torrc
+  candidate=$(sudo mktemp /etc/tor/torrc.joininbox.XXXXXX) || exit 1
+  trap 'sudo rm -f -- "$candidate"' EXIT
+  sudo sed "/# Hidden Service for ${service}/,/^\s*$/{d}" /etc/tor/torrc | \
+    awk 'NF > 0 {blank=0} NF == 0 {blank++} blank < 2' | \
+    sudo tee "$candidate" >/dev/null || exit 1
 
-  # make new entry for that service
   echo "
 # Hidden Service for $service
 HiddenServiceDir $HiddenServiceDir/$service
 HiddenServiceVersion 3
-HiddenServicePort $toPort 127.0.0.1:$fromPort" | sudo tee -a /etc/tor/torrc
-
-  # remove double empty lines
-  awk 'NF > 0 {blank=0} NF == 0 {blank++} blank < 2' /etc/tor/torrc | sudo tee /home/joinmarket/tmp >/dev/null && sudo mv /home/joinmarket/tmp /etc/tor/torrc
+HiddenServicePort $toPort 127.0.0.1:$fromPort" | sudo tee -a "$candidate" >/dev/null
 
   # check and insert second port pair
   if [ ${#toPort2} -gt 0 ]; then
-    alreadyThere=$(sudo cat /etc/tor/torrc 2>/dev/null | grep -c "\b127.0.0.1:$fromPort2\b")
+    alreadyThere=$(sudo grep -c "\b127.0.0.1:$fromPort2\b" "$candidate" 2>/dev/null)
     if [ ${alreadyThere} -gt 0 ]; then
       echo "The port $fromPort2 is already forwarded. Check the /etc/tor/torrc for the details."
     else
-      echo "HiddenServicePort $toPort2 127.0.0.1:$fromPort2" | sudo tee -a /etc/tor/torrc
+      echo "HiddenServicePort $toPort2 127.0.0.1:$fromPort2" | sudo tee -a "$candidate" >/dev/null
     fi
   fi
+
+  installTorrc "$candidate"
+  trap - EXIT
 
   # reload tor
   echo
   echo "Reloading Tor to activate the Hidden Service..."
-  sudo chmod 644 /etc/tor/torrc
   sudo systemctl reload tor
   sleep 10
 

--- a/scripts/install.hiddenservice.sh
+++ b/scripts/install.hiddenservice.sh
@@ -15,6 +15,19 @@ fi
 source /home/joinmarket/_functions.sh
 sourceConf /home/joinmarket/joinin.conf
 
+# hidden-service base directory: strict absolute path, no whitespace or control
+# characters, must live under an expected Tor data root
+validateHiddenServiceDir() {
+  case "$1" in
+    /var/lib/tor|/mnt/hdd/tor) ;;
+    *)
+      echo "ERROR: unexpected HiddenServiceDir: $1" >&2
+      echo "Expected /var/lib/tor or /mnt/hdd/tor - refusing to continue" >&2
+      exit 1
+      ;;
+  esac
+}
+
 validateService() {
   case "$1" in
     ''|*[!A-Za-z0-9_-]*)
@@ -51,6 +64,38 @@ installTorrc() {
   sudo mv -f -- "$candidate" /etc/tor/torrc
 }
 
+# Generate a candidate torrc without the block of the given service.
+# Every stage is checked explicitly so a failed read or write never produces
+# an empty or truncated candidate that would replace the live torrc.
+generateTorrcCandidate() {
+  service="$1"
+  candidate="$2"
+  stage=$(sudo mktemp) || exit 1
+  if ! sudo sed "/# Hidden Service for ${service}/,/^\s*$/{d}" /etc/tor/torrc > "$stage"; then
+    echo "ERROR: failed to read/process /etc/tor/torrc" >&2
+    sudo rm -f -- "$stage"
+    exit 1
+  fi
+  # a failed read must not yield an empty candidate
+  if [ ! -s "$stage" ]; then
+    echo "ERROR: processed torrc is empty - refusing to install" >&2
+    sudo rm -f -- "$stage"
+    exit 1
+  fi
+  if ! sudo awk 'NF > 0 {blank=0} NF == 0 {blank++} blank < 2' "$stage" | \
+    sudo tee "$candidate" >/dev/null; then
+    echo "ERROR: failed to write the candidate torrc" >&2
+    sudo rm -f -- "$stage"
+    exit 1
+  fi
+  if [ ! -s "$candidate" ]; then
+    echo "ERROR: generated candidate is empty - refusing to install" >&2
+    sudo rm -f -- "$stage"
+    exit 1
+  fi
+  sudo rm -f -- "$stage"
+}
+
 # delete a hidden service
 if [ "$1" == "off" ]; then
 
@@ -59,9 +104,7 @@ if [ "$1" == "off" ]; then
 
   candidate=$(sudo mktemp /etc/tor/torrc.joininbox.XXXXXX) || exit 1
   trap 'sudo rm -f -- "$candidate"' EXIT
-  sudo sed "/# Hidden Service for ${service}/,/^\s*$/{d}" /etc/tor/torrc | \
-    awk 'NF > 0 {blank=0} NF == 0 {blank++} blank < 2' | \
-    sudo tee "$candidate" >/dev/null || exit 1
+  generateTorrcCandidate "$service" "$candidate"
   installTorrc "$candidate"
   trap - EXIT
 
@@ -99,8 +142,7 @@ if [ ${#toPort2} -gt 0 ]; then
   validatePort "$fromPort2"
 fi
 
-checkDirEntry=$(grep -c "HiddenServiceDir" < /home/joinmarket/joinin.conf)
-if [ "$checkDirEntry" -eq 0 ]; then
+if [ -z "$HiddenServiceDir" ]; then
   if [ -d "/mnt/hdd/tor" ] ; then
     HiddenServiceDir="/mnt/hdd/tor"
   else
@@ -108,14 +150,13 @@ if [ "$checkDirEntry" -eq 0 ]; then
   fi
   echo "HiddenServiceDir=$HiddenServiceDir" >> /home/joinmarket/joinin.conf
 fi
+validateHiddenServiceDir "$HiddenServiceDir"
 
 if [ "${runBehindTor}" = "on" ]; then
 
   candidate=$(sudo mktemp /etc/tor/torrc.joininbox.XXXXXX) || exit 1
   trap 'sudo rm -f -- "$candidate"' EXIT
-  sudo sed "/# Hidden Service for ${service}/,/^\s*$/{d}" /etc/tor/torrc | \
-    awk 'NF > 0 {blank=0} NF == 0 {blank++} blank < 2' | \
-    sudo tee "$candidate" >/dev/null || exit 1
+  generateTorrcCandidate "$service" "$candidate"
 
   echo "
 # Hidden Service for $service
@@ -143,11 +184,11 @@ HiddenServicePort $toPort 127.0.0.1:$fromPort" | sudo tee -a "$candidate" >/dev/
   sleep 10
 
   # show the Hidden Service address
-  TOR_ADDRESS=$(sudo cat $HiddenServiceDir/$service/hostname)
+  TOR_ADDRESS=$(sudo cat "$HiddenServiceDir/$service/hostname")
   if [ -z "$TOR_ADDRESS" ]; then
     echo "Waiting for the Hidden Service"
     sleep 10
-    TOR_ADDRESS=$(sudo cat $HiddenServiceDir/$service/hostname)
+    TOR_ADDRESS=$(sudo cat "$HiddenServiceDir/$service/hostname")
     if [ -z "$TOR_ADDRESS" ]; then
       echo " FAIL - The Hidden Service address could not be found - Tor error?"
       exit 1
@@ -158,7 +199,7 @@ HiddenServicePort $toPort 127.0.0.1:$fromPort" | sudo tee -a "$candidate" >/dev/
   echo "$TOR_ADDRESS"
   echo "use with the port: $toPort"
   if [ ${#toPort2} -gt 0 ]; then
-    wasAdded=$(sudo cat /etc/tor/torrc 2>/dev/null | grep -c "\b127.0.0.1:$fromPort2\b")
+    wasAdded=$(sudo grep -c "\b127.0.0.1:$fromPort2\b" /etc/tor/torrc 2>/dev/null)
     if [ ${wasAdded} -gt 0 ]; then
       echo "or the port: $toPort2"
     fi

--- a/scripts/install.hiddenservice.sh
+++ b/scripts/install.hiddenservice.sh
@@ -4,6 +4,11 @@
 # $2 is the port the Hidden Service forwards to (to be used in the Tor browser)
 # $3 is the port to be forwarded with the Hidden Service
 
+# Detect failures anywhere in a pipeline (eg sed | tee): without pipefail only
+# the last command's status is observed, so a failed producer writing partial
+# output would go unnoticed and could yield a truncated candidate torrc.
+set -o pipefail
+
 # command info
 if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
  echo "config script to configure a Tor Hidden Service"


### PR DESCRIPTION
## Summary

- validate hidden-service identifiers against a conservative allowlist
- require numeric ports in the range 1-65535
- generate candidate Tor configuration in a root-owned temporary file beside `torrc`
- validate candidates with `tor --verify-config` before an atomic rename
- preserve the previous configuration when generation or validation fails
- keep `/etc/tor/torrc` owned by root and remove world-writable staging files
- reload Tor through systemd rather than signalling processes by name

This implements the Tor configuration recommendations from #186.

## Security impact

Previously, unvalidated values were interpolated into `sed` expressions and Tor directives, and configuration rewrites passed through a mode-0777 file owned outside `/etc`. A malformed value or local race could corrupt or alter Tor configuration. The new flow validates inputs, stages changes under `/etc/tor`, asks Tor to parse the complete candidate, and installs it atomically only on success.

## Tests

- `bash -n scripts/install.hiddenservice.sh`
- `git diff --check`
- verified removal of `chmod 777`, `chown bitcoin:bitcoin`, and `pkill` from the script

Runtime Tor integration should also be exercised by the image CI on both standalone and RaspiBlitz layouts.
