### PR TITLE
security: constrain generated wallet service inputs

### DIFF
--- a/scripts/_functions.menu.sh
+++ b/scripts/_functions.menu.sh
@@ -26,18 +26,40 @@ function menu_MAKER() {
   chooseWallet noLockFileCheck
   # save wallet in conf
   sudo sed -i "s#^YGwallet=.*#YGwallet=$(cat $wallet)#g" $joininConfPath
-  # get password
+  # validate the service inputs BEFORE creating the password file
+  walletInput=$(cat $wallet)
+  if ! walletCanonical=$(validateServiceArgs yg-privacyenhanced "$walletInput"); then
+    echo
+    echo "# ERROR: the wallet input was rejected - the Yield Generator was not started"
+    echo "# Press ENTER to return to the menu."
+    read key
+    /home/joinmarket/menu.yg.sh
+    return 1
+  fi
+  # get password (creates /dev/shm/.pw)
   passwordToFile
-  echo "# Using the wallet: $(cat $wallet)"
-  /home/joinmarket/start.service.sh yg-privacyenhanced $(cat $wallet)
-  echo
-  echo "# started the Yield Generator in the background"
-  echo
-  echo "# showing the systemd status ..."
-  sleep 3
-  dialog \
-  --title "Monitoring the Yield Generator - press CTRL+C to exit"  \
-  --prgbox "sudo journalctl -fn100 -u yg-privacyenhanced" -1 -1
+  echo "# Using the wallet: $walletCanonical"
+  if /home/joinmarket/start.service.sh yg-privacyenhanced "$walletCanonical"; then
+    echo
+    echo "# started the Yield Generator in the background"
+    echo
+    echo "# showing the systemd status ..."
+    sleep 3
+    dialog \
+    --title "Monitoring the Yield Generator - press CTRL+C to exit"  \
+    --prgbox "sudo journalctl -fn100 -u yg-privacyenhanced" -1 -1
+  else
+    startStatus=$?
+    echo
+    echo "# ERROR: the Yield Generator failed to start (exit code $startStatus)"
+    # remove the password temp file left behind by the failed start
+    if [ -f /dev/shm/.pw ]; then
+      shred -uvz /dev/shm/.pw
+      echo "# Removed the password temp file /dev/shm/.pw"
+    fi
+    echo "# Press ENTER to return to the menu."
+    read key
+  fi
   echo "# returning to the menu..."
   sleep 1
   /home/joinmarket/menu.yg.sh

--- a/scripts/_functions.sh
+++ b/scripts/_functions.sh
@@ -186,6 +186,45 @@ function chooseWallet() {
   fi
 }
 
+# validateServiceArgs <script> <walletInput>
+# Validates a systemd service name and wallet input for start.service.sh.
+# Prints the canonical wallet path on stdout when valid.
+# Returns 1 (message on stderr) when the input is rejected.
+# Used to reject bad input BEFORE any credential file (/dev/shm/.pw) is created.
+function validateServiceArgs() {
+  local script="$1"
+  local walletInput="$2"
+
+  if [ "$script" != "yg-privacyenhanced" ]; then
+    echo "# Refusing unsupported service: $script" >&2
+    return 1
+  fi
+
+  if [ -L "$walletInput" ]; then
+    echo "# Refusing a symlink as wallet input" >&2
+    return 1
+  fi
+  local wallet
+  wallet=$(readlink -f -- "$walletInput") || return 1
+  local walletDirectory
+  walletDirectory=$(readlink -f -- "$walletPath") || return 1
+  local walletFileName
+  walletFileName=$(basename -- "$wallet")
+  case "$walletFileName" in
+    ''|*[!A-Za-z0-9._-]*)
+      echo "# Refusing unsafe wallet filename" >&2
+      return 1
+      ;;
+  esac
+  if [ ! -f "$wallet" ] || \
+    [ "$(dirname -- "$wallet")" != "$walletDirectory" ]; then
+    echo "# Wallet must be a regular file directly inside $walletDirectory" >&2
+    return 1
+  fi
+
+  echo "$wallet"
+}
+
 # stopYG <wallet>
 function stopYG() {
   if [ $# -eq 1 ]; then

--- a/scripts/start.service.sh
+++ b/scripts/start.service.sh
@@ -6,14 +6,32 @@ sourceConf /home/joinmarket/joinin.conf
 script="$1"
 wallet="$2"
 
-if [ $script == "yg-privacyenhanced" ]; then
-  stopYG $wallet
-else
-echo
-  echo "# Making sure $script is not running"
-  sudo systemctl stop $script
-  sudo systemctl disable $script
+if [ "$script" != "yg-privacyenhanced" ]; then
+  echo "# Refusing unsupported service: $script" >&2
+  exit 1
 fi
+
+walletInput="$wallet"
+if [ -L "$walletInput" ]; then
+  echo "# Refusing a symlink as wallet input" >&2
+  exit 1
+fi
+wallet=$(readlink -f -- "$walletInput") || exit 1
+walletDirectory=$(readlink -f -- "$walletPath") || exit 1
+walletFileName=$(basename -- "$wallet")
+case "$walletFileName" in
+  ''|*[!A-Za-z0-9._-]*)
+    echo "# Refusing unsafe wallet filename" >&2
+    exit 1
+    ;;
+esac
+if [ ! -f "$wallet" ] || \
+  [ "$(dirname -- "$wallet")" != "$walletDirectory" ]; then
+  echo "# Wallet must be a regular file directly inside $walletDirectory" >&2
+  exit 1
+fi
+
+stopYG "$wallet"
 
 if [ "${RPCoverTor}" = "on" ];then
   tor="torsocks"
@@ -24,7 +42,6 @@ fi
 startScript="cat /dev/shm/.pw | $tor python $script.py $wallet \
 --wallet-password-stdin"
 # display
-walletFileName="${wallet//$walletPath/ }"
 echo
 echo "# Running the command with systemd:"
 echo " $tor python $script.py $walletFileName"
@@ -69,6 +86,7 @@ echo
 echo "# Starting the systemd service: $script"
 echo
 
+sudo systemctl daemon-reload
 sudo systemctl enable $script
 sudo systemctl start $script
 

--- a/scripts/start.service.sh
+++ b/scripts/start.service.sh
@@ -4,32 +4,12 @@ source /home/joinmarket/_functions.sh
 sourceConf /home/joinmarket/joinin.conf
 
 script="$1"
-wallet="$2"
+walletInput="$2"
 
-if [ "$script" != "yg-privacyenhanced" ]; then
-  echo "# Refusing unsupported service: $script" >&2
-  exit 1
-fi
-
-walletInput="$wallet"
-if [ -L "$walletInput" ]; then
-  echo "# Refusing a symlink as wallet input" >&2
-  exit 1
-fi
-wallet=$(readlink -f -- "$walletInput") || exit 1
-walletDirectory=$(readlink -f -- "$walletPath") || exit 1
-walletFileName=$(basename -- "$wallet")
-case "$walletFileName" in
-  ''|*[!A-Za-z0-9._-]*)
-    echo "# Refusing unsafe wallet filename" >&2
-    exit 1
-    ;;
-esac
-if [ ! -f "$wallet" ] || \
-  [ "$(dirname -- "$wallet")" != "$walletDirectory" ]; then
-  echo "# Wallet must be a regular file directly inside $walletDirectory" >&2
-  exit 1
-fi
+# Validate and canonicalize ALL inputs at the very top,
+# before anything touches credential files (e.g. /dev/shm/.pw)
+# or makes any system changes.
+wallet=$(validateServiceArgs "$script" "$walletInput") || exit 1
 
 stopYG "$wallet"
 


### PR DESCRIPTION
## Summary

- constrain the generated service to the intended `yg-privacyenhanced` program
- reject wallet symlinks and paths outside the wallet directory
- restrict wallet filenames to conservative characters before interpolation
- quote calls into service-management helpers
- reload systemd after writing the unit

This addresses the command/unit injection finding documented in #186 while retaining the existing Yield Generator startup flow.

## Security impact

`start.service.sh` previously accepted arbitrary program names and paths, interpolated them into `/bin/sh -c`, a systemd unit, and a root-controlled unit filename. An attacker able to influence those arguments could inject commands or make privileged systemctl operations target unintended units. The script now has a single allowed program and requires a canonical regular wallet file directly below the expected wallet directory.

## Tests

- `bash -n scripts/start.service.sh`
- `git diff --check`

This can later be stacked with the private credential transport change in #187 to remove the remaining fixed `/dev/shm/.pw` path.
