### PR TITLE
security: verify JoininBox updates before install

### DIFF
--- a/build_joininbox.sh
+++ b/build_joininbox.sh
@@ -424,7 +424,7 @@ else
     echo "# The last commit was made on GitHub and is signed with the GitHub PGP key."
     PGPsigner="web-flow"
     PGPpubkeyLink="https://github.com/${PGPsigner}.gpg"
-    PGPpubkeyFingerprint="B5690EEEBB952194"
+    PGPpubkeyFingerprint="968479A1AFF927E37D1A566BB5690EEEBB952194"
   else
     echo "# No known PGP key found"
     exit 1

--- a/scripts/_functions.sh
+++ b/scripts/_functions.sh
@@ -331,9 +331,18 @@ function updateJoininBox() {
     TAG=$(git describe --tags)
     echo "# Updating to the latest commit in the default branch"
   elif [ "$1" = "pr" ]; then
-    echo "# Refusing to install pull-request code into privileged script paths." >&2
-    echo "# Test pull requests in an isolated development image instead." >&2
-    return 1
+    PRnumber=$2
+    echo ""
+    echo "##########################################################" >&2
+    echo "# WARNING: installing UNVERIFIED pull-request code" >&2
+    echo "# https://github.com/openoms/joininbox/pull/$PRnumber" >&2
+    echo "# This code is NOT signed by a maintainer and will run" >&2
+    echo "# with elevated privileges on this system." >&2
+    echo "##########################################################" >&2
+    echo ""
+    sudo -u joinmarket git fetch origin pull/$PRnumber/head:pr$PRnumber || return 1
+    sudo -u joinmarket git checkout pr$PRnumber || return 1
+    TAG=$(git describe --tags)
   else
     TAG=$(git tag | sort -V | tail -1)
     # unset $1
@@ -346,7 +355,9 @@ function updateJoininBox() {
     fi
     sudo -u joinmarket git reset --hard $TAG
   fi
-  if [ "$1" = "commit" ]; then
+  if [ "$1" = "pr" ]; then
+    echo "# Skipping signature verification for unverified PR code"
+  elif [ "$1" = "commit" ]; then
     verifyJoininBoxRef HEAD commit || return 1
   else
     verifyJoininBoxRef "$TAG" tag || return 1

--- a/scripts/_functions.sh
+++ b/scripts/_functions.sh
@@ -281,6 +281,35 @@ function copyJoininboxScripts() {
 }
 
 # updateJoininBox <reset|commit|pr[PRnumber]>
+function verifyJoininBoxRef() {
+  local ref="$1"
+  local kind="$2"
+  local signer keyUrl fingerprint signature
+
+  if [ "$kind" = "tag" ]; then
+    signer="openoms"
+    keyUrl="https://github.com/openoms.gpg"
+    fingerprint="13C688DB5B9C745DE4D2E4545BFB77609B081B65"
+    /home/joinmarket/verify.git.sh "$signer" "$keyUrl" "$fingerprint" "$ref"
+    return
+  fi
+
+  signature=$(git log -1 --show-signature --format=oneline "$ref" 2>&1)
+  if echo "$signature" | grep -q '13C688DB5B9C745DE4D2E4545BFB77609B081B65'; then
+    signer="openoms"
+    keyUrl="https://github.com/openoms.gpg"
+    fingerprint="13C688DB5B9C745DE4D2E4545BFB77609B081B65"
+  elif echo "$signature" | grep -q 'B5690EEEBB952194'; then
+    signer="web-flow"
+    keyUrl="https://github.com/web-flow.gpg"
+    fingerprint="968479A1AFF927E37D1A566BB5690EEEBB952194"
+  else
+    echo "# Refusing an update without a recognized signing key" >&2
+    return 1
+  fi
+  /home/joinmarket/verify.git.sh "$signer" "$keyUrl" "$fingerprint"
+}
+
 function updateJoininBox() {
   cd /home/joinmarket || exit 1
   if [ "$1" = "reset" ] ||  [ "$1" = "pr" ];then
@@ -302,12 +331,9 @@ function updateJoininBox() {
     TAG=$(git describe --tags)
     echo "# Updating to the latest commit in the default branch"
   elif [ "$1" = "pr" ]; then
-    PRnumber=$2
-    echo "# Using the PR:"
-    echo "# https://github.com/JoinMarket-Org/joinmarket-clientserver/release/tag/$PRnumber"
-    sudo -u joinmarket git fetch origin pull/$PRnumber/head:pr$PRnumber
-    sudo -u joinmarket git checkout pr$PRnumber
-    TAG=$(git describe --tags)
+    echo "# Refusing to install pull-request code into privileged script paths." >&2
+    echo "# Test pull requests in an isolated development image instead." >&2
+    return 1
   else
     TAG=$(git tag | sort -V | tail -1)
     # unset $1
@@ -319,6 +345,11 @@ function updateJoininBox() {
       echo "# You are up-to-date on version" $TAG
     fi
     sudo -u joinmarket git reset --hard $TAG
+  fi
+  if [ "$1" = "commit" ]; then
+    verifyJoininBoxRef HEAD commit || return 1
+  else
+    verifyJoininBoxRef "$TAG" tag || return 1
   fi
   echo "# Current version: $TAG"
   copyJoininboxScripts

--- a/scripts/_functions.sh
+++ b/scripts/_functions.sh
@@ -280,6 +280,17 @@ function copyJoininboxScripts() {
   fi
 }
 
+# Accept only a decimal GitHub pull-request number. This is checked before any
+# repository removal and before constructing the fetch refspec.
+function validatePRNumber() {
+  case "$1" in
+    ''|*[!0-9]*)
+      echo "# Invalid pull-request number: $1" >&2
+      return 1
+      ;;
+  esac
+}
+
 # updateJoininBox <reset|commit|pr[PRnumber]>
 function verifyJoininBoxRef() {
   local ref="$1"
@@ -311,6 +322,9 @@ function verifyJoininBoxRef() {
 }
 
 function updateJoininBox() {
+  if [ "$1" = "pr" ]; then
+    validatePRNumber "$2" || return 1
+  fi
   cd /home/joinmarket || exit 1
   if [ "$1" = "reset" ] ||  [ "$1" = "pr" ];then
     echo "# Removing the joininbox source code"

--- a/scripts/menu.update.advanced.sh
+++ b/scripts/menu.update.advanced.sh
@@ -48,9 +48,24 @@ case $CHOICE in
   JBPR)
       echo
       read -p "Enter the number of the pull request to be tested: " PRnumber
-      read -p "Continue to install the PR:
-https://github.com/openoms/joininbox/pull/$PRnumber
-(Y/N)? " confirm && [[ $confirm == [yY]||$confirm == [yY][eE][sS] ]]||exit 1
+      echo
+      echo "#################### SECURITY WARNING ####################"
+      echo "# You are about to install UNVERIFIED pull-request code:"
+      echo "# https://github.com/openoms/joininbox/pull/$PRnumber"
+      echo "#"
+      echo "# - Anyone on GitHub can open a pull request."
+      echo "# - The code is NOT signed by a maintainer."
+      echo "# - It will run with elevated privileges on this system."
+      echo "#"
+      echo "# Only proceed if you have read the PR diff and trust"
+      echo "# the author. Otherwise test PRs in an isolated image."
+      echo "##########################################################"
+      echo
+      read -p "Type 'test PR $PRnumber' to confirm: " confirm
+      if [ "$confirm" != "test PR $PRnumber" ]; then
+        echo "# Not confirmed - cancelling"
+        exit 1
+      fi
       updateJoininBox pr $PRnumber
       errorOnInstall $?
       echo

--- a/scripts/menu.update.advanced.sh
+++ b/scripts/menu.update.advanced.sh
@@ -48,6 +48,7 @@ case $CHOICE in
   JBPR)
       echo
       read -p "Enter the number of the pull request to be tested: " PRnumber
+      validatePRNumber "$PRnumber" || exit 1
       echo
       echo "#################### SECURITY WARNING ####################"
       echo "# You are about to install UNVERIFIED pull-request code:"

--- a/scripts/verify.git.sh
+++ b/scripts/verify.git.sh
@@ -73,7 +73,12 @@ echo
 cat "$_temp"
 echo "# goodSignature(${goodSignature})"
 
-correctKey=$(grep -F "[GNUPG:] VALIDSIG ${PGPpubkeyFingerprint} " "$_temp" -c)
+# VALIDSIG starts with the signing-key fingerprint, which is a subkey when the
+# signer uses one (e.g. AdamISZ signs tags with a signing subkey). The primary
+# key fingerprint is the last field of the record. Accept the pinned fingerprint
+# in either position - GnuPG only reports it after validating the signature and
+# the subkey binding, so both bind the signature to the pinned key.
+correctKey=$(grep -E "^\[GNUPG:\] VALIDSIG (${PGPpubkeyFingerprint} |.* ${PGPpubkeyFingerprint}\$)" "$_temp" -c)
 echo "# correctKey(${correctKey})"
 
 if [ "${correctKey}" -lt 1 ] || [ "${goodSignature}" -lt 1 ]; then

--- a/scripts/verify.git.sh
+++ b/scripts/verify.git.sh
@@ -62,7 +62,9 @@ elif [ $# -eq 4 ] && [ -n "$4" ]; then
   commitOrTag="$4 tag"
 fi
 echo "# running: ${gitCommand}"
-if ${gitCommand} 2>&1 >&"$_temp"; then
+# --raw includes GnuPG's machine-readable VALIDSIG record with the complete
+# signing-key fingerprint. Do not authenticate signatures using a short key ID.
+if ${gitCommand} --raw >"$_temp" 2>&1; then
   goodSignature=1
 else
   goodSignature=0
@@ -71,7 +73,7 @@ echo
 cat "$_temp"
 echo "# goodSignature(${goodSignature})"
 
-correctKey=$(tr -d " \t\n\r" <"$_temp" | grep "${PGPpubkeyFingerprint}" -c)
+correctKey=$(grep -F "[GNUPG:] VALIDSIG ${PGPpubkeyFingerprint} " "$_temp" -c)
 echo "# correctKey(${correctKey})"
 
 if [ "${correctKey}" -lt 1 ] || [ "${goodSignature}" -lt 1 ]; then

--- a/tests/verified-updates.bats
+++ b/tests/verified-updates.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+
+FUNCTIONS="$BATS_TEST_DIRNAME/../scripts/_functions.sh"
+
+setup() {
+  BIN="$BATS_TEST_TMPDIR/bin"
+  VERIFY_LOG="$BATS_TEST_TMPDIR/verify.log"
+  mkdir -p "$BIN"
+  cat >"$BIN/git" <<'EOF'
+#!/bin/bash
+printf '%s\n' "${SIGNATURE_OUTPUT:-unknown signer}"
+EOF
+  cat >"$BIN/verify" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$*" >>"$VERIFY_LOG"
+exit "${VERIFY_STATUS:-0}"
+EOF
+  chmod +x "$BIN"/*
+  export PATH="$BIN:$PATH" VERIFY_LOG
+
+  sed -n '/^function verifyJoininBoxRef()/,/^}/p' "$FUNCTIONS" |
+    sed "s#/home/joinmarket/verify.git.sh#$BIN/verify#" >"$BATS_TEST_TMPDIR/function.sh"
+  source "$BATS_TEST_TMPDIR/function.sh"
+}
+
+@test "tag updates pin the openoms key and pass the tag to verification" {
+  run verifyJoininBoxRef v1.2.3 tag
+  [ "$status" -eq 0 ]
+  grep -q '^openoms https://github.com/openoms.gpg 13C688DB5B9C745DE4D2E4545BFB77609B081B65 v1.2.3$' "$VERIFY_LOG"
+}
+
+@test "commit updates select the openoms key from the signed commit" {
+  export SIGNATURE_OUTPUT='Good signature 13C688DB5B9C745DE4D2E4545BFB77609B081B65'
+  run verifyJoininBoxRef HEAD commit
+  [ "$status" -eq 0 ]
+  grep -q '^openoms https://github.com/openoms.gpg 13C688DB5B9C745DE4D2E4545BFB77609B081B65$' "$VERIFY_LOG"
+}
+
+@test "GitHub commit updates expand the recognized key ID to the full pinned fingerprint" {
+  export SIGNATURE_OUTPUT='Good signature B5690EEEBB952194'
+  run verifyJoininBoxRef HEAD commit
+  [ "$status" -eq 0 ]
+  grep -q '^web-flow https://github.com/web-flow.gpg 968479A1AFF927E37D1A566BB5690EEEBB952194$' "$VERIFY_LOG"
+}
+
+@test "commit updates fail closed for an unrecognized signer" {
+  export SIGNATURE_OUTPUT='Good signature DEADBEEF'
+  run verifyJoininBoxRef HEAD commit
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Refusing an update"* ]]
+  [ ! -s "$VERIFY_LOG" ]
+}
+
+@test "PR update UI requires the PR-specific typed confirmation" {
+  menu="$BATS_TEST_DIRNAME/../scripts/menu.update.advanced.sh"
+  grep -Fq 'Type '\''test PR $PRnumber'\'' to confirm' "$menu"
+  grep -Fq '[ "$confirm" != "test PR $PRnumber" ]' "$menu"
+  grep -Fq 'installing UNVERIFIED pull-request code' "$FUNCTIONS"
+  grep -Fq 'Skipping signature verification for unverified PR code' "$FUNCTIONS"
+}
+
+@test "image builds pin GitHub web-flow with its full fingerprint" {
+  build="$BATS_TEST_DIRNAME/../build_joininbox.sh"
+  grep -Fq 'PGPpubkeyFingerprint="968479A1AFF927E37D1A566BB5690EEEBB952194"' "$build"
+  ! grep -Fq 'PGPpubkeyFingerprint="B5690EEEBB952194"' "$build"
+}

--- a/tests/verified-updates.bats
+++ b/tests/verified-updates.bats
@@ -18,9 +18,23 @@ EOF
   chmod +x "$BIN"/*
   export PATH="$BIN:$PATH" VERIFY_LOG
 
-  sed -n '/^function verifyJoininBoxRef()/,/^}/p' "$FUNCTIONS" |
+  sed -n -e '/^function validatePRNumber()/,/^}/p' \
+    -e '/^function verifyJoininBoxRef()/,/^}/p' "$FUNCTIONS" |
     sed "s#/home/joinmarket/verify.git.sh#$BIN/verify#" >"$BATS_TEST_TMPDIR/function.sh"
   source "$BATS_TEST_TMPDIR/function.sh"
+}
+
+@test "PR numbers are decimal before any fetch refspec is constructed" {
+  for number in 1 190 999999; do
+    run validatePRNumber "$number"
+    [ "$status" -eq 0 ]
+  done
+  for number in '' -1 1.5 '190/head' '190;id' '--upload-pack=evil'; do
+    run validatePRNumber "$number"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Invalid pull-request number"* ]]
+  done
+  grep -Fq 'validatePRNumber "$2" || return 1' "$FUNCTIONS"
 }
 
 @test "tag updates pin the openoms key and pass the tag to verification" {

--- a/tests/verify.git.bats
+++ b/tests/verify.git.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+
+SCRIPT="$BATS_TEST_DIRNAME/../scripts/verify.git.sh"
+FPR='13C688DB5B9C745DE4D2E4545BFB77609B081B65'
+
+setup() {
+  BIN="$BATS_TEST_TMPDIR/bin"
+  CALLS="$BATS_TEST_TMPDIR/calls"
+  mkdir -p "$BIN"
+  : >"$CALLS"
+
+  cat >"$BIN/wget" <<'EOF'
+#!/bin/bash
+printf 'PUBLIC KEY\n' >"$3"
+EOF
+  cat >"$BIN/gpg" <<'EOF'
+#!/bin/bash
+if [[ "$*" == *'--show-keys'* ]]; then
+  printf '%s\n' "${KEY_FINGERPRINT:-$EXPECTED_FPR}"
+fi
+exit 0
+EOF
+  cat >"$BIN/git" <<'EOF'
+#!/bin/bash
+printf 'git %s\n' "$*" >>"$CALLS"
+if [ "$1" = log ]; then
+  printf 'abc123 signed commit\n'
+  exit 0
+fi
+printf '%s\n' "${VALIDSIG:-[GNUPG:] VALIDSIG $EXPECTED_FPR 2026 0 4 0 1 10 00 $EXPECTED_FPR}"
+exit "${VERIFY_EXIT:-0}"
+EOF
+  chmod +x "$BIN"/*
+  export PATH="$BIN:$PATH" CALLS EXPECTED_FPR="$FPR"
+}
+
+@test "verifies a commit with the exact pinned fingerprint and --raw" {
+  run bash "$SCRIPT" openoms https://example.test/key "$FPR"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"abc123 commit is correct"* ]]
+  grep -q '^git verify-commit abc123 --raw$' "$CALLS"
+}
+
+@test "accepts a signing subkey when VALIDSIG binds it to the pinned primary key" {
+  export VALIDSIG="[GNUPG:] VALIDSIG AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA 2026 0 4 0 1 10 00 $FPR"
+  run bash "$SCRIPT" openoms https://example.test/key "$FPR" v1.2.3
+  [ "$status" -eq 0 ]
+  grep -q '^git verify-tag v1.2.3 --raw$' "$CALLS"
+}
+
+@test "rejects a valid signature made by a different key" {
+  export VALIDSIG='[GNUPG:] VALIDSIG AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA 2026 0 4 0 1 10 00 BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
+  run bash "$SCRIPT" openoms https://example.test/key "$FPR"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"verify(0)"* ]]
+}
+
+@test "rejects a failed git verification even when output names the pinned key" {
+  export VERIFY_EXIT=1
+  run bash "$SCRIPT" openoms https://example.test/key "$FPR"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"signature(0)"* ]]
+}
+
+@test "rejects a downloaded key that lacks the pinned fingerprint" {
+  export KEY_FINGERPRINT='BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
+  run bash "$SCRIPT" openoms https://example.test/key "$FPR"
+  [ "$status" -eq 7 ]
+  [[ "$output" == *"fingerprint is not as expected"* ]]
+}


### PR DESCRIPTION
## Summary

- verify every release-tag or default-branch update before copying installed scripts
- recognize only pinned full fingerprints for openoms and GitHub `web-flow`
- use GnuPG's machine-readable `VALIDSIG` record and support bound signing subkeys
- fail closed when a commit is unsigned or signed by an unknown key
- retain JoininBox PR testing behind a prominent warning and exact typed consent
- validate PR numbers as decimal before deleting a checkout or constructing a fetch refspec

This implements the update-authenticity recommendations from #186.

## Security impact

The existing updater fetched a moving branch and copied it into `/home/joinmarket` without calling the repository's signature verifier. Because installed scripts can invoke privileged operations, repository or account compromise could become root compromise on updating nodes. Signed release/default-branch paths now authenticate the selected immutable tag or commit before `copyJoininboxScripts` runs.

Short key IDs are not authentication boundaries. `verify.git.sh` captures `git verify-* --raw` output and requires an exact full-fingerprint `VALIDSIG` record. It accepts the pinned fingerprint either as the signing key or as the final bound primary-key field, allowing legitimate signing subkeys without weakening the trust boundary.

## PR-testing compatibility

Advanced PR testing remains available for hardware testing, but the menu clearly states that PR code is unverified and runs with elevated privileges. The operator must type `test PR <number>` exactly. Direct callers also receive a warning banner. PR numbers are restricted to decimal digits before any destructive checkout step or fetch refspec construction. Testing untrusted PRs in an isolated image is recommended.

## Tests

- `tests/verify.git.bats`: commit/tag success, bound subkey, wrong key, failed signature, wrong downloaded key
- `tests/verified-updates.bats`: trusted signer selection, unknown signer rejection, typed PR consent, decimal PR validation, full GitHub fingerprint pin
- `bash -n` / ShellCheck / spelling
- amd64 and arm64 image builds
