### PR TITLE
security: remove root wildcard deletion in /dev/shm

### DIFF
--- a/scripts/menu.quickstart.sh
+++ b/scripts/menu.quickstart.sh
@@ -31,7 +31,15 @@ function cacheAndShowQR() {
   qrencode -t ANSIUTF8 "${firstNewAddress}"
   echo
   shred $wallet $mixdepth $walletData
-  sudo rm -f /dev/shm/*
+  # shred does not delete files by default, so remove the exact temp files
+  # created by this script. /dev/shm is a shared, world-writable directory:
+  # never glob-delete there (especially not as root) - only remove files
+  # owned by the calling user that this script itself created.
+  rm -f "$walletData"
+  rm -f "$wallet"
+  if [ -n "$mixdepth" ]; then
+    rm -f "$mixdepth"
+  fi
 }
 
 # BASIC MENU INFO

--- a/tests/menu.quickstart-cleanup.bats
+++ b/tests/menu.quickstart-cleanup.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+
+setup() {
+  TEST_ROOT="$BATS_TEST_TMPDIR/root"
+  MOCK_BIN="$TEST_ROOT/bin"
+  mkdir -p "$MOCK_BIN"
+  export PATH="$MOCK_BIN:$PATH"
+
+  cat >"$MOCK_BIN/wallet-tool" <<'EOF'
+#!/bin/bash
+printf '0.00000000\tnew-address\n'
+EOF
+  cat >"$MOCK_BIN/qrencode" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+  cat >"$MOCK_BIN/shred" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+  chmod +x "$MOCK_BIN"/*
+
+  # Load only the function under test, replacing its absolute service path
+  # with the harmless wallet-tool fixture above.
+  sed -n '/^function cacheAndShowQR()/,/^}/p' \
+    "$BATS_TEST_DIRNAME/../scripts/menu.quickstart.sh" |
+    sed "s#/home/joinmarket/start.script.sh#$MOCK_BIN/wallet-tool#" >"$TEST_ROOT/function.sh"
+  source "$TEST_ROOT/function.sh"
+}
+
+@test "removes only the wallet, mixdepth and function-owned cache" {
+  wallet="$TEST_ROOT/wallet"
+  mixdepth="$TEST_ROOT/mixdepth"
+  sentinel="/dev/shm/joininbox-quickstart-sentinel.$$"
+  touch "$wallet" "$mixdepth" "$sentinel"
+
+  run cacheAndShowQR
+  [ "$status" -eq 0 ]
+  [ ! -e "$wallet" ]
+  [ ! -e "$mixdepth" ]
+  [ -e "$sentinel" ]
+  rm -f "$sentinel"
+}
+
+@test "handles an empty optional mixdepth without glob deletion" {
+  wallet="$TEST_ROOT/wallet"
+  mixdepth=""
+  sentinel="/dev/shm/joininbox-quickstart-sentinel.$$"
+  touch "$wallet" "$sentinel"
+
+  run cacheAndShowQR
+  [ "$status" -eq 0 ]
+  [ ! -e "$wallet" ]
+  [ -e "$sentinel" ]
+  rm -f "$sentinel"
+}


### PR DESCRIPTION
## Summary

Fixes security finding **#11** from the hardening plan (SECURITY-HARDENING.md, see PR #186).

`scripts/menu.quickstart.sh` ran `sudo rm -f /dev/shm/*` as root after displaying wallet data. `/dev/shm` is a world-writable shared tmpfs, so a root wildcard deletion there can:

- delete **other processes' files** in `/dev/shm` (e.g. `/dev/shm/.pw` written by `_functions.sh` during password entry, temp files of concurrently running menus, or unrelated processes)
- is **race-prone** (TOCTOU between glob expansion and deletion in a world-writable directory)
- requires **unnecessary root privileges** — the temp files are created by `mktemp` as the calling `joinmarket` user, so no `sudo` is needed to remove them

## What changed

`scripts/menu.quickstart.sh` (`cacheAndShowQR`):

- Removed `sudo rm -f /dev/shm/*`
- After the existing `shred` call (kept as-is; note `shred` does not delete files by default and overwriting is unreliable on tmpfs anyway), the script now deletes **only the exact temp files it created/used** with plain `rm -f`:
  - `$walletData` (its own `mktemp -p /dev/shm/` file)
  - `$wallet` (the `mktemp -p /dev/shm/` file from `chooseWallet`, previously only cleaned by the root glob or the EXIT trap)
  - `$mixdepth` (guarded with `[ -n ... ]` since it is unset in this flow)
- No `sudo` — all removed files are owned by the calling user

## Test plan

- `bash -n scripts/menu.quickstart.sh` → **OK** (syntax clean)
- shellcheck is not installed on the authoring host; the change only adds quoted `rm -f` calls and introduces no new unquoted expansions (the pre-existing `shred $wallet $mixdepth $walletData` line is untouched)
- Functional smoke test replicating the cleanup block in a scratch dir:
  - two `mktemp` files simulating `$wallet`/`$walletData` → **deleted**
  - an unrelated `other_process_file` in the same directory → **survives** (previously it would have been removed by the root glob)

## Follow-ups (not changed in this PR)

Other root wildcard deletions exist elsewhere in the repo. They are in root-owned (not world-writable) directories so they are lower risk than `/dev/shm`, but still worth tightening in separate PRs:

- `scripts/standalone/prepare.release.sh:17` — `sudo rm /etc/ssh/ssh_host_*`
- `ci/amd64/debian/scripts/joininbox.sh:10` — `sudo rm /etc/ssh/ssh_host_*`
- `scripts/jam-remote/install.jam.sh:169-170` — `sudo rm -f /etc/nginx/sites-{enabled,available}/jam*`