### PR TITLE
security: replace eval-based argument parsing in installer

### DIFF
--- a/scripts/install.joinmarket.sh
+++ b/scripts/install.joinmarket.sh
@@ -51,6 +51,16 @@ error_msg() {
   printf %s"${red}${me}: ${1}${nocolor}\n"
   exit 1
 }
+valid_var_name() {
+  [[ "${1}" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]
+}
+reject_shell_syntax() {
+  # fail closed on characters that enable command injection
+  local forbidden='[;&|`$<>]'
+  if [[ "${1}" =~ ${forbidden} ]]; then
+    error_msg "Invalid characters in: '${1}'"
+  fi
+}
 assign_value() {
   case "${2}" in
   --*) value="${2#--}" ;;
@@ -61,7 +71,9 @@ assign_value() {
   0) value="false" ;;
   1) value="true" ;;
   esac
-  eval "${1}"="\"${value}\""
+  valid_var_name "${1}" || error_msg "Invalid variable name: '${1}'"
+  reject_shell_syntax "${value}"
+  printf -v "${1}" '%s' "${value}"
 }
 
 get_arg() {
@@ -73,7 +85,8 @@ get_arg() {
 
 range_argument() {
   name="${1}"
-  eval var='$'"${1}"
+  valid_var_name "${name}" || error_msg "Invalid variable name: '${name}'"
+  var="${!name}"
   shift
   if [ -n "${var:-}" ]; then
     success=0

--- a/tests/install.joinmarket-args.bats
+++ b/tests/install.joinmarket-args.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+
+SCRIPT="$BATS_TEST_DIRNAME/../scripts/install.joinmarket.sh"
+
+@test "help documents supported arguments without evaluating input" {
+  run bash "$SCRIPT" --help
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"--install"* ]]
+  [[ "$output" == *"--version"* ]]
+}
+
+@test "rejects command substitution in an option value" {
+  marker="$BATS_TEST_TMPDIR/injected"
+  run bash "$SCRIPT" "--install=\$(touch $marker)"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Invalid characters"* ]]
+  [ ! -e "$marker" ]
+}
+
+@test "rejects shell separators in an option value" {
+  marker="$BATS_TEST_TMPDIR/injected"
+  run bash "$SCRIPT" "--version=v0.9.11;touch $marker"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Invalid characters"* ]]
+  [ ! -e "$marker" ]
+}
+
+@test "rejects redirection and pipeline syntax" {
+  run bash "$SCRIPT" '--user=joinmarket>/tmp/result'
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Invalid characters"* ]]
+
+  run bash "$SCRIPT" '--user=joinmarket|id'
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Invalid characters"* ]]
+}


### PR DESCRIPTION
## Summary

Fixes finding **#10** from the security hardening plan (SECURITY-HARDENING.md, see PR #186): `scripts/install.joinmarket.sh` used `eval` for CLI argument parsing.

- `assign_value()` ran `eval "${1}"="\"${value}\""` — a crafted option value like `--install '$(id)'` executed arbitrary shell commands.
- `range_argument()` ran `eval var='$'"${1}"` on the variable name — a crafted name also executed arbitrary shell.

This is particularly dangerous because the script performs privileged (`sudo`) operations.

## What changed

- **`assign_value()`**: validates the target variable name against `^[a-zA-Z_][a-zA-Z0-9_]*$]` (rejects otherwise via `error_msg`), rejects values containing shell metacharacters (`;` `&` `|` `` ` ` `$` `<` `>`), then assigns safely with `printf -v "$name" '%s' "$value"` — no `eval`, no interpretation of the value.
- **`range_argument()`**: validates the name the same way, then reads via indirect expansion `${!name}` instead of `eval`.
- New helpers `valid_var_name()` / `reject_shell_syntax()` fail closed with a clear `error_msg`.
- CLI interface and behavior for legitimate inputs are unchanged (dash-stripping, `0/1 → false/true` mapping, range validation, defaults all preserved). Calls happen at top level, so `printf -v` assigns globals exactly as `eval` did.

Other `eval` usage in the repo: `grep -rn 'eval '` finds **no** other eval on caller-controlled input — this was the only file (left untouched per PR scope: SECURITY-HARDENING.md / SECURITY.md not modified).

## Test plan

`bash -n` passes. A throwaway harness (in /tmp, not committed) sources the patched helpers and ran **15 checks, all passing**:

- **Legitimate inputs still work:** `assign_value install update`, `0/1 → false/true` mapping, dash-stripping (`--bob` → `bob`), `get_arg version -v v0.9.12`, `range_argument` accepts valid / rejects invalid values, indirect read `${!name}` correct.
- **Malicious inputs fail closed with no code execution** (verified no side-effect file created):
  - names: `x;touch /tmp/pwned`, `a$(touch /tmp/pwned)`
  - values: `$(touch /tmp/pwned)`, `` `touch /tmp/pwned` ``, `a$(reboot); touch /tmp/pwned`, `x;touch /tmp/pwned`
- **End-to-end through the real CLI parse loop:**
  - `--install '$(touch /tmp/pwned)'` → `Invalid characters in: '$(touch /tmp/pwned)'`, no file created
  - `--install=update --qtgui=1 --user=bob` → parses and proceeds normally
  - `--install bogus` → `Option '--install' cannot be 'bogus'! It can only be: install config update testPR commit.`

shellcheck is not installed in this environment; no new constructs were introduced that change existing warning classes.
