### PR TITLE
security: stop sourcing user-writable config as shell code

### DIFF
--- a/scripts/_functions.bitcoincore.sh
+++ b/scripts/_functions.bitcoincore.sh
@@ -286,7 +286,7 @@ function showBitcoinLogs() {
     lines="-n $1"
     echo "# Show $lines number of lines"
   fi
-  source ${joininConfPath}
+  sourceConf ${joininConfPath}
   if [ ${#network} -eq 0 ] || [ "${network}" = "mainnet" ] || [ "${runningEnv}" = "raspiblitz" ]; then
     bitcoinUser="bitcoin"
   elif [ "${network}" = "signet" ]; then
@@ -534,7 +534,7 @@ function connectLocalNode() {
   if [ ${#1} -gt 0 ]; then
     network=$1
   else
-    source ${joininConfPath}
+    sourceConf ${joininConfPath}
   fi
   echo "# Setting connection to the local Bitcoin node on ${network}"
   rpc_host="127.0.0.1"

--- a/scripts/_functions.bitcoincore.sh
+++ b/scripts/_functions.bitcoincore.sh
@@ -5,6 +5,12 @@ walletPath="/home/joinmarket/.joinmarket/wallets/"
 JMcfgPath="/home/joinmarket/.joinmarket/joinmarket.cfg"
 joininConfPath="/home/joinmarket/joinin.conf"
 
+# sourceConf is defined in _functions.sh - source it if this file is used
+# standalone (no-op when sourced via _functions.sh, which defines it first)
+if ! declare -F sourceConf >/dev/null 2>&1; then
+  source /home/joinmarket/_functions.sh
+fi
+
 # downloadBitcoinCore
 function downloadBitcoinCore() {
   # set version

--- a/scripts/_functions.sh
+++ b/scripts/_functions.sh
@@ -1,6 +1,51 @@
 #!/bin/bash
 
-source /home/joinmarket/joinin.conf
+# sourceConf <config-file>
+# Parse a KEY=value config file as DATA - never execute it as shell code.
+# Fails closed: aborts with a non-zero exit and an error on stderr naming the
+# file and line number if any line is malformed or contains characters that
+# have no legitimate use in this config (and could be used for code execution
+# if the file was sourced as shell code).
+function sourceConf() {
+  local confFile="$1"
+  local line key value lineNr=0
+  if [ ! -f "$confFile" ]; then
+    echo "# sourceConf ERROR: config file not found: $confFile" >&2
+    exit 1
+  fi
+  # read from the file directly (not a pipe) so variables stay in this shell
+  while IFS= read -r line || [ -n "$line" ]; do
+    lineNr=$((lineNr + 1))
+    # allow blank lines and comments
+    if [ -z "$line" ] || [[ "$line" =~ ^[[:space:]]*# ]]; then
+      continue
+    fi
+    # valid lines must be KEY=value
+    if ! [[ "$line" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; then
+      echo "# sourceConf ERROR: malformed line $lineNr in $confFile" >&2
+      exit 1
+    fi
+    key="${line%%=*}"
+    value="${line#*=}"
+    # reject characters with no legitimate use in this config that would be
+    # dangerous if the file was ever executed as shell code
+    # shellcheck disable=SC2016 # the '$(' etc. below are intentional literals
+    if [[ "$value" == *'`'* || "$value" == *'$('* || "$value" == *';'* || \
+          "$value" == *'|'* || "$value" == *'&'* || \
+          "$value" == *'<'* || "$value" == *'>'* ]]; then
+      echo "# sourceConf ERROR: forbidden character in the value on line $lineNr in $confFile" >&2
+      exit 1
+    fi
+    # strip one pair of matching surrounding quotes (as the shell would when sourcing)
+    if [[ "$value" =~ ^\'(.*)\'$ ]] || [[ "$value" =~ ^\"(.*)\"$ ]]; then
+      value="${BASH_REMATCH[1]}"
+    fi
+    # assign as data (global scope) - never eval
+    declare -g "$key=$value"
+  done < "$confFile"
+}
+
+sourceConf /home/joinmarket/joinin.conf
 
 # versions
 currentJBcommit=$(cd /home/joinmarket/joininbox; git describe --tags)

--- a/scripts/info.importwallet.sh
+++ b/scripts/info.importwallet.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-source /home/joinmarket/joinin.conf
+source /home/joinmarket/_functions.sh
+sourceConf /home/joinmarket/joinin.conf
 
 # Basic Options
 OPTIONS=(LAN "Computers on the same network" \

--- a/scripts/info.qtgui.sh
+++ b/scripts/info.qtgui.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 source /home/joinmarket/_functions.sh
-source /home/joinmarket/joinin.conf
+sourceConf /home/joinmarket/joinin.conf
 
 checkRPCwallet
 

--- a/scripts/install.bitcoincore.sh
+++ b/scripts/install.bitcoincore.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-source /home/joinmarket/joinin.conf
 source /home/joinmarket/_functions.sh
+sourceConf /home/joinmarket/joinin.conf
 
 # check connectedRemoteNode var in joinin.conf
 if ! grep -Eq "^connectedRemoteNode=" $joininConfPath; then

--- a/scripts/install.hiddenservice.sh
+++ b/scripts/install.hiddenservice.sh
@@ -12,7 +12,8 @@ if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
  exit 1
 fi
 
-source /home/joinmarket/joinin.conf
+source /home/joinmarket/_functions.sh
+sourceConf /home/joinmarket/joinin.conf
 
 # delete a hidden service
 if [ "$1" == "off" ]; then

--- a/scripts/install.joinmarket-api.sh
+++ b/scripts/install.joinmarket-api.sh
@@ -11,7 +11,8 @@ if [ ${#1} -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
   echo "start.joinmarket-api.sh connect"
 fi
 
-source $HOME_DIR/joinin.conf
+source $HOME_DIR/_functions.sh
+sourceConf $HOME_DIR/joinin.conf
 
 function joinmarketApiServiceOn() {
 

--- a/scripts/install.joinmarket.sh
+++ b/scripts/install.joinmarket.sh
@@ -128,7 +128,7 @@ range_argument qtgui "0" "1" "false" "true"
 : "${user:=joinmarket}"
 
 source /home/joinmarket/_functions.sh
-source /home/joinmarket/joinin.conf
+sourceConf /home/joinmarket/joinin.conf
 
 # create user if not default
 if [ "${user}" != "joinmarket" ]; then

--- a/scripts/menu.config.sh
+++ b/scripts/menu.config.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-source /home/joinmarket/joinin.conf
 source /home/joinmarket/_functions.sh
+sourceConf /home/joinmarket/joinin.conf
 
 if [ ${#network} -eq 0 ] || [ "${network}" = "unknown" ] ;then
   if [ "${runningEnv}" = standalone ]; then
@@ -11,9 +11,9 @@ if [ ${#network} -eq 0 ] || [ "${network}" = "unknown" ] ;then
     network=mainnet
   elif [ "${runningEnv}" = raspiblitz ];then
     if [ -f "/mnt/hdd/raspiblitz.conf" ]; then
-      source /mnt/hdd/raspiblitz.conf
+      sourceConf /mnt/hdd/raspiblitz.conf
     else
-      source /mnt/hdd/app-data/raspiblitz.conf
+      sourceConf /mnt/hdd/app-data/raspiblitz.conf
     fi
     if [ $network = bitcoin ];then
       network=${chain}net

--- a/scripts/menu.freeze.sh
+++ b/scripts/menu.freeze.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-source /home/joinmarket/joinin.conf
 source /home/joinmarket/_functions.sh
+sourceConf /home/joinmarket/joinin.conf
 
 chooseWallet
 

--- a/scripts/menu.jam.sh
+++ b/scripts/menu.jam.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
-source /home/joinmarket/joinin.conf
+source /home/joinmarket/_functions.sh
+sourceConf /home/joinmarket/joinin.conf
 if [ -f "/mnt/hdd/raspiblitz.conf" ]; then
-  source /mnt/hdd/raspiblitz.conf
+  sourceConf /mnt/hdd/raspiblitz.conf
 else
-  source /mnt/hdd/app-data/raspiblitz.conf
+  sourceConf /mnt/hdd/app-data/raspiblitz.conf
 fi
 
 # BASIC MENU INFO

--- a/scripts/menu.orderbook.sh
+++ b/scripts/menu.orderbook.sh
@@ -3,8 +3,8 @@
 # menu.orderbook.sh -> starts the menu
 # menu.orderbook.sh startOrderBookService starts the orderBookService
 
-source /home/joinmarket/joinin.conf
 source /home/joinmarket/_functions.sh
+sourceConf /home/joinmarket/joinin.conf
 
 # the bitcoind wallet needs to be loaded for the ob-watcher.py also
 checkRPCwallet

--- a/scripts/menu.payjoin.sh
+++ b/scripts/menu.payjoin.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-source /home/joinmarket/joinin.conf
 source /home/joinmarket/_functions.sh
+sourceConf /home/joinmarket/joinin.conf
 
 checkRPCwallet
 

--- a/scripts/menu.quickstart.sh
+++ b/scripts/menu.quickstart.sh
@@ -2,8 +2,8 @@
 
 # QUICKSTART menu options
 
-source /home/joinmarket/joinin.conf
 source /home/joinmarket/_functions.sh
+sourceConf /home/joinmarket/joinin.conf
 
 checkRPCwallet
 

--- a/scripts/menu.send.sh
+++ b/scripts/menu.send.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-source /home/joinmarket/joinin.conf
 source /home/joinmarket/_functions.sh
+sourceConf /home/joinmarket/joinin.conf
 
 checkRPCwallet
 

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 /home/joinmarket/start.joininbox.sh
-source /home/joinmarket/joinin.conf
 source /home/joinmarket/_functions.sh
+sourceConf /home/joinmarket/joinin.conf
 
 # BASIC MENU INFO
 HEIGHT=21

--- a/scripts/menu.tools.sh
+++ b/scripts/menu.tools.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-source /home/joinmarket/joinin.conf
 source /home/joinmarket/_functions.sh
+sourceConf /home/joinmarket/joinin.conf
 
 function installBitcoinScripts {
   if [ ! -d "/home/bitcoin/bitcoin-scripts" ]; then

--- a/scripts/menu.wallet.sh
+++ b/scripts/menu.wallet.sh
@@ -2,8 +2,8 @@
 
 # WALLET menu options
 
-source /home/joinmarket/joinin.conf
 source /home/joinmarket/_functions.sh
+sourceConf /home/joinmarket/joinin.conf
 
 if [ ${RPCoverTor} = "on" ]; then
   tor="torsocks"

--- a/scripts/menu.yg.sh
+++ b/scripts/menu.yg.sh
@@ -2,7 +2,7 @@
 # YG menu options
 
 source /home/joinmarket/_functions.sh
-source /home/joinmarket/joinin.conf
+sourceConf /home/joinmarket/joinin.conf
 
 if [ ${RPCoverTor} = "on" ]; then
   tor="torsocks"

--- a/scripts/standalone/install.i2pd.sh
+++ b/scripts/standalone/install.i2pd.sh
@@ -107,7 +107,8 @@ function bitcoinI2Pstatus {
 }
 
 echo "# Running: 'install.i2pd.sh $*'"
-source /home/joinmarket/joinin.conf
+source /home/joinmarket/_functions.sh
+sourceConf /home/joinmarket/joinin.conf
 
 bitcoinConfPath="/home/bitcoin/.bitcoin/bitcoin.conf"
 bitcoinLogPath="/home/bitcoin/.bitcoin/debug.log"

--- a/scripts/standalone/install.specter.sh
+++ b/scripts/standalone/install.specter.sh
@@ -15,7 +15,7 @@ fi
 echo "# install.specter.sh $1"
 
 source /home/joinmarket/_functions.sh
-source /home/joinmarket/joinin.conf
+sourceConf /home/joinmarket/joinin.conf
 
 function createSpecterConfig() {
     echo "# Creating /home/specter/.specter/config.json"
@@ -304,7 +304,7 @@ EOF
   sudo sed -i "s/^specter=.*/specter=on/g" /home/joinmarket/joinin.conf
 
   # Hidden Service for SERVICE if Tor is active
-  source /home/joinmarket/joinin.conf
+  sourceConf /home/joinmarket/joinin.conf
   if [ "${runBehindTor}" = "on" ]; then
     # make sure to keep in sync with internet.tor.sh script
     # port 25441 is HTTPS with self-signed cert - specter only makes sense to be served over HTTPS

--- a/scripts/start.joininbox.sh
+++ b/scripts/start.joininbox.sh
@@ -17,7 +17,7 @@ if [ "$setupStepEntry" -eq 0 ]; then
   echo "setupStep=0" >>$joininConfPath
 fi
 
-source /home/joinmarket/joinin.conf
+sourceConf /home/joinmarket/joinin.conf
 if [ "$setupStep" -lt 100 ]; then
   if [ "$setupStep" -lt 5 ]; then
     # identify running env
@@ -95,13 +95,13 @@ if [ "$setupStep" -lt 100 ]; then
   fi
   # change the ssh password if standalone
   if [ "$runningEnv" = "standalone" ]; then
-    source /home/joinmarket/joinin.conf
+    sourceConf /home/joinmarket/joinin.conf
     if [ "$setupStep" -lt 6 ]; then
       # set ssh passwords on the first run
       sudo /home/joinmarket/set.password.sh
       sed -i "s#setupStep=.*#setupStep=6#g" $joininConfPath
     fi
-    source /home/joinmarket/joinin.conf
+    sourceConf /home/joinmarket/joinin.conf
     if [ "$setupStep" -lt 7 ] && [ ${cpu} != "x86_64" ]; then
       # expand SDcard partition on ARM
       sudo /home/joinmarket/standalone/expand.rootfs.sh
@@ -109,7 +109,7 @@ if [ "$setupStep" -lt 100 ]; then
   fi
   generateJMconfig
   sudo sed -i "s#setupStep=.*#setupStep=10#g" $joininConfPath
-  source /home/joinmarket/joinin.conf
+  sourceConf /home/joinmarket/joinin.conf
   if [ "$setupStep" -lt 11 ]; then
     if [ "$runningEnv" = "standalone" ]; then
       # open the config menu if standalone

--- a/scripts/start.script.sh
+++ b/scripts/start.script.sh
@@ -57,7 +57,7 @@ else
   nickname="-T $8"
 fi
 
-source /home/joinmarket/joinin.conf
+sourceConf /home/joinmarket/joinin.conf
 if [ ${RPCoverTor} = "on" ]; then
   tor="torsocks"
 else

--- a/scripts/start.service.sh
+++ b/scripts/start.service.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-source /home/joinmarket/joinin.conf
 source /home/joinmarket/_functions.sh
+sourceConf /home/joinmarket/joinin.conf
 
 script="$1"
 wallet="$2"


### PR DESCRIPTION
## Summary

Fixes **finding #2** from `SECURITY-HARDENING.md` (see PR #186): 20+ scripts ran `source /home/joinmarket/joinin.conf` — a file writable by the unprivileged `joinmarket` user — including in scripts that perform privileged operations via `sudo`. Since a sourced file is executed as shell code, any command written into `joinin.conf` would run with the privileges of the sourcing script.

This PR adds a `sourceConf()` parser to `scripts/_functions.sh` that reads `KEY=value` config files **as data, never as code**, and converts every `source`/`.` of a user-writable `.conf` file to use it.

## What changed

**New `sourceConf()` in `scripts/_functions.sh`** (copied to `/home/joinmarket/_functions.sh` by `copyJoininboxScripts` — verified):

- Reads the file line by line (redirect, not a pipe, so variables persist in the calling shell)
- Allows blank lines and `#` comments
- Valid lines must match `^[A-Za-z_][A-Za-z0-9_]*=.*`
- **Fails closed** (non-zero exit + error to stderr naming the file and line number) on:
  - malformed lines
  - values containing a backtick, `$(`, `;`, `|`, `&`, `<` or `>` — none of these have a legitimate use in this config
  - a missing config file
- Strips one pair of matching surrounding single/double quotes (so values written by `set.value.sh` as `key='value'` behave exactly as when sourced)
- Assigns with `declare -g` — **never `eval`**

**Converted files** (every occurrence found by `grep -rn "source.*joinin\.conf\|\. .*joinin\.conf" scripts/`):

- `scripts/_functions.sh` (also hosts `sourceConf`)
- `scripts/_functions.bitcoincore.sh` (2× `source ${joininConfPath}`)
- Reordered so `_functions.sh` (which defines `sourceConf`) is sourced first: `menu.sh`, `start.service.sh`, `menu.quickstart.sh`, `menu.send.sh`, `menu.tools.sh`, `install.bitcoincore.sh`, `menu.config.sh`, `menu.payjoin.sh`, `menu.wallet.sh`, `menu.freeze.sh`, `menu.orderbook.sh`
- Simple replacements (ordering was already fine): `start.joininbox.sh` (4×), `info.qtgui.sh`, `menu.yg.sh`, `install.joinmarket.sh`, `start.script.sh`, `standalone/install.specter.sh` (2×)
- Added `source /home/joinmarket/_functions.sh` where it was missing entirely, then converted: `menu.jam.sh`, `install.hiddenservice.sh`, `install.joinmarket-api.sh`, `standalone/install.i2pd.sh`, `info.importwallet.sh`

**Other writable/conf files found during the audit** (also converted):

- `menu.jam.sh` and `menu.config.sh` also sourced `/mnt/hdd/raspiblitz.conf` / `/mnt/hdd/app-data/raspiblitz.conf` — the same "sourcing a config as code" pattern; converted to `sourceConf` as well. Format audit: `raspiblitz.conf` is strictly `KEY=value`, compatible with the parser.
- `set.value.sh` only ever writes `/home/joinmarket/joinin.conf` (the extra file argument some callers pass is ignored by the script — pre-existing upstream quirk, not changed here).
- `set.conf.sh` is a generic dialog editor used on `joinmarket.cfg` / `bitcoin.conf`, which are parsed by JoinMarket/Bitcoin Core, never sourced by these scripts.
- No `joinin.conf.local` or other sourced user-writable conf files exist.

**Legitimate value shapes accepted** (from `build_joininbox.sh`, `set.value.sh`, install scripts): `on`/`off`, `true`/`false`, numbers, plain paths (`HiddenServiceDir=/var/lib/tor/...`), hostnames/`.onion:port`, and single-quoted strings with spaces. Behavior for normal configs is identical — verified by diffing the resulting variables against real `source` (see below).

## Test plan / evidence

- `bash -n` over **all** scripts: `find scripts -name '*.sh' -exec bash -n {} +` → clean.
- ShellCheck 0.10.0 on all changed files: **no new warnings** (rule-count comparison vs `upstream/master`; SC1090/SC1091 info notices reduced 64→36 since the dynamic `source` calls are gone).
- Dedicated harness (`24 passed, 0 failed`) exercising the exact parser extracted from `_functions.sh`:
  - **Normal config**: all variables set correctly; output **byte-identical** to `source` for the same file:
    `on|signet|10|false|/var/lib/tor/hidden_service_ssh|some value with spaces|host.onion:8332|true|off`
  - **Malicious configs — nothing executed, parser aborted (rc=1) with file + line number on stderr** for each of: `x=$(touch /tmp/pwned1)`, ``x=`touch /tmp/pwned2` ``, `x=1; touch /tmp/pwned3`, `x=1 | touch …`, `x=1 && touch …`, `x=1 > file`, `x=1 < /etc/passwd`, a shell function definition `pwn() { …; }`, a bare command line `touch /tmp/pwned9`, and `x=$(id)> file`. No `/tmp/pwned*` marker file was ever created.
  - Malformed key (`1bad=2`) → abort naming file and line 2; missing file → abort; literal `\n` kept as inert data; a real newline produces a malformed line → abort (newline injection cannot execute).
  - Variables persist in the calling shell after `sourceConf` returns (no subshell).

Example reject output:
```
# sourceConf ERROR: forbidden character in the value on line 1 in /tmp/mal.conf
```

**Note:** this was validated statically and with the parser harness only — a full menu-flow test on a real JoininBox node (main menu, CONFIG, send/freeze/wallet menus, standalone scripts) is still needed before merge.
