### PR TITLE
fix(ci): make image builds noninteractive

### DIFF
--- a/.github/workflows/amd64-image-build.yml
+++ b/.github/workflows/amd64-image-build.yml
@@ -33,11 +33,16 @@ jobs:
         id: set_values
         run: |
           echo "BUILD_DATE=$(date +"%Y-%m-%d")" >> $GITHUB_ENV
-          echo "BUILD_VERSION=$(git describe --always --tags)" >> $GITHUB_ENV
           if [[ "${{github.event_name}}" == "pull_request" ]]; then
             echo "::set-output name=github_user::${{github.event.pull_request.head.repo.owner.login}}"
+            # PR builds skip the code signature verification and are
+            # labeled with the PR number - for testing only.
+            # Master (production) builds keep verification mandatory.
+            echo "JOININBOX_PR_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+            echo "BUILD_VERSION=$(git describe --always --tags)-pr${{ github.event.pull_request.number }}" >> $GITHUB_ENV
           else
             echo "::set-output name=github_user::$(echo ${{github.repository}} | cut -d'/' -f1)"
+            echo "BUILD_VERSION=$(git describe --always --tags)" >> $GITHUB_ENV
           fi
 
       - name: Display the build name
@@ -47,7 +52,7 @@ jobs:
         run: |
           echo "Running with: ${{steps.set_values.outputs.github_user}} $GITHUB_HEAD_REF"
           cd ci/amd64
-          bash packer.build.amd64-debian.sh ${{steps.set_values.outputs.github_user}} $GITHUB_HEAD_REF
+          bash packer.build.amd64-debian.sh ${{steps.set_values.outputs.github_user}} $GITHUB_HEAD_REF "$JOININBOX_PR_NUMBER"
 
       - name: Compute checksum of the raw image
         run: |

--- a/.github/workflows/arm64-rpi-image-build.yml
+++ b/.github/workflows/arm64-rpi-image-build.yml
@@ -35,11 +35,16 @@ jobs:
         id: set_values
         run: |
           echo "BUILD_DATE=$(date +"%Y-%m-%d")" >> $GITHUB_ENV
-          echo "BUILD_VERSION=$(git describe --always --tags)" >> $GITHUB_ENV
           if [[ "${{github.event_name}}" == "pull_request" ]]; then
             echo "::set-output name=github_user::${{github.event.pull_request.head.repo.owner.login}}"
+            # PR builds skip the code signature verification and are
+            # labeled with the PR number - for testing only.
+            # Master (production) builds keep verification mandatory.
+            echo "JOININBOX_PR_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+            echo "BUILD_VERSION=$(git describe --always --tags)-pr${{ github.event.pull_request.number }}" >> $GITHUB_ENV
           else
             echo "::set-output name=github_user::$(echo ${{github.repository}} | cut -d'/' -f1)"
+            echo "BUILD_VERSION=$(git describe --always --tags)" >> $GITHUB_ENV
           fi
 
       - name: Display the build name
@@ -54,7 +59,7 @@ jobs:
         run: |
           echo "Running with: ${{steps.set_values.outputs.github_user}} $GITHUB_HEAD_REF"
           cd ci/arm64-rpi
-          bash arm64-rpi.sh ${{steps.set_values.outputs.github_user}} $GITHUB_HEAD_REF
+          bash arm64-rpi.sh ${{steps.set_values.outputs.github_user}} $GITHUB_HEAD_REF "$JOININBOX_PR_NUMBER"
 
       - name: Compute checksum of the raw image
         run: |

--- a/build_joininbox.sh
+++ b/build_joininbox.sh
@@ -677,3 +677,7 @@ echo "the ssh login credentials are until the first login:"
 echo "user:joinmarket"
 echo "password:joininbox"
 echo
+
+# remove the build-time noninteractive apt policy so deployed systems
+# keep the default interactive conffile handling
+rm -f /etc/apt/apt.conf.d/90joininbox-noninteractive

--- a/build_joininbox.sh
+++ b/build_joininbox.sh
@@ -394,28 +394,48 @@ else
   fi
 fi
 
-echo "# Checking which key signed the last commit"
-lastCommit=$(sudo -u joinmarket git log --show-signature --oneline | head -n6)
-echo ${lastCommit}
-if echo "${lastCommit}" | grep 13C688DB5B9C745DE4D2E4545BFB77609B081B65; then
-  PGPsigner="openoms"
-  PGPpubkeyLink="https://github.com/openoms.gpg"
-  PGPpubkeyFingerprint="13C688DB5B9C745DE4D2E4545BFB77609B081B65"
-elif echo "${lastCommit}" | grep B5690EEEBB952194; then
-  echo "# The last commit was made on GitHub and is signed with the GitHub PGP key."
-  PGPsigner="web-flow"
-  PGPpubkeyLink="https://github.com/${PGPsigner}.gpg"
-  PGPpubkeyFingerprint="B5690EEEBB952194"
+if [ -n "$JOININBOX_PR_NUMBER" ]; then
+  # Pull-request CI build: the head commit comes from a fork and is not
+  # expected to be signed by a maintainer key. Skip code verification,
+  # but label the image clearly as an unverified test build.
+  # Production images are only built on push to master where this
+  # variable is empty and verification below is mandatory.
+  echo "########################################################"
+  echo "# PULL REQUEST BUILD #${JOININBOX_PR_NUMBER}"
+  echo "# SKIPPING the PGP verification of the source code"
+  echo "# This image is for TESTING ONLY - not for production use"
+  echo "########################################################"
+  echo "# Labeling the image as an unverified PR build"
+  echo "pr_build=${JOININBOX_PR_NUMBER}
+github_user=${githubUser}
+branch=${wantedBranch}
+built=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+warning=UNVERIFIED pull request build - for testing only" \
+    > /etc/joininbox-build-info
 else
-  echo "# No known PGP key found"
-  exit 1
-fi
+  echo "# Checking which key signed the last commit"
+  lastCommit=$(sudo -u joinmarket git log --show-signature --oneline | head -n6)
+  echo ${lastCommit}
+  if echo "${lastCommit}" | grep 13C688DB5B9C745DE4D2E4545BFB77609B081B65; then
+    PGPsigner="openoms"
+    PGPpubkeyLink="https://github.com/openoms.gpg"
+    PGPpubkeyFingerprint="13C688DB5B9C745DE4D2E4545BFB77609B081B65"
+  elif echo "${lastCommit}" | grep B5690EEEBB952194; then
+    echo "# The last commit was made on GitHub and is signed with the GitHub PGP key."
+    PGPsigner="web-flow"
+    PGPpubkeyLink="https://github.com/${PGPsigner}.gpg"
+    PGPpubkeyFingerprint="B5690EEEBB952194"
+  else
+    echo "# No known PGP key found"
+    exit 1
+  fi
 
-command="bash /home/joinmarket/joininbox/scripts/verify.git.sh \
-  ${PGPsigner} ${PGPpubkeyLink} ${PGPpubkeyFingerprint}"
-echo "running: ${command}"
-chmod 777 /dev/shm
-sudo -u joinmarket ${command} || exit 1
+  command="bash /home/joinmarket/joininbox/scripts/verify.git.sh \
+    ${PGPsigner} ${PGPpubkeyLink} ${PGPpubkeyFingerprint}"
+  echo "running: ${command}"
+  chmod 777 /dev/shm
+  sudo -u joinmarket ${command} || exit 1
+fi
 
 runuser joinmarket -c "cp /home/joinmarket/joininbox/scripts/* /home/joinmarket/"
 runuser joinmarket -c "cp /home/joinmarket/joininbox/scripts/.* /home/joinmarket/ 2>/dev/null"

--- a/build_joininbox.sh
+++ b/build_joininbox.sh
@@ -266,6 +266,13 @@ echo "########################"
 echo "# apt-get update & upgrade"
 echo "########################"
 echo
+# noninteractive package management:
+# - debconf never prompts (no tty in CI/packer builds)
+# - dpkg conffile prompts (eg initramfs.conf during kernel upgrades)
+#   resolve to the default action and keep the existing config
+export DEBIAN_FRONTEND=noninteractive
+echo 'Dpkg::Options { "--force-confdef"; "--force-confold"; }' \
+  > /etc/apt/apt.conf.d/90joininbox-noninteractive
 apt-get update -y
 apt-get upgrade -f -y
 
@@ -337,7 +344,12 @@ apt-get install -y net-tools
 # to display hex codes
 apt-get install -y xxd
 # netcat
-apt-get install -y netcat
+# the netcat metapackage was removed in Debian trixie - use the openbsd variant
+if apt-cache show netcat >/dev/null 2>&1; then
+  apt-get install -y netcat
+else
+  apt-get install -y netcat-openbsd
+fi
 # install killall, fuser
 apt-get install -y psmisc
 # dialog

--- a/ci/amd64/debian/build.amd64-debian.pkr.hcl
+++ b/ci/amd64/debian/build.amd64-debian.pkr.hcl
@@ -10,6 +10,10 @@ variable "iso_checksum" { default = "file:https://cdimage.debian.org/debian-cd/c
 
 variable "github_user" { default = "openoms" }
 variable "branch" { default = "master" }
+# set to the pull-request number for PR CI builds: skips the code
+# signature verification and labels the image as an unverified test build.
+# Empty for master (production) builds where verification is mandatory.
+variable "pr_number" { default = "" }
 
 variable "boot" { default = "uefi" }
 variable "preseed_file" { default = "preseed.cfg" }
@@ -91,7 +95,8 @@ build {
     environment_vars = [
       "HOME_DIR=/home/joinmarket",
       "github_user=${var.github_user}",
-      "branch=${var.branch}"
+      "branch=${var.branch}",
+      "pr_number=${var.pr_number}"
     ]
 
     execute_command   = "echo 'joininbox' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'"

--- a/ci/amd64/debian/scripts/joininbox.sh
+++ b/ci/amd64/debian/scripts/joininbox.sh
@@ -4,7 +4,7 @@ echo 'Download the build_joininbox.sh script ...'
 wget https://raw.githubusercontent.com/${github_user}/joininbox/${branch}/build_joininbox.sh
 
 echo 'Build Joininbox ...'
-sudo bash build_joininbox.sh "${github_user}" "${branch}" "commit"
+sudo env JOININBOX_PR_NUMBER="${pr_number}" bash build_joininbox.sh "${github_user}" "${branch}" "commit"
 
 echo 'Delete SSH keys (will be recreated on the first boot)'
 sudo rm /etc/ssh/ssh_host_*

--- a/ci/amd64/debian/scripts/update.sh
+++ b/ci/amd64/debian/scripts/update.sh
@@ -15,5 +15,12 @@ systemctl daemon-reload
 
 apt-get update
 
+# no tty in the packer build: debconf must not prompt and dpkg conffile
+# questions (eg initramfs.conf during kernel upgrades) resolve to the
+# default action while keeping the existing config
+export DEBIAN_FRONTEND=noninteractive
+echo 'Dpkg::Options { "--force-confdef"; "--force-confold"; }' \
+  > /etc/apt/apt.conf.d/90joininbox-noninteractive
+
 apt-get -y upgrade linux-image-$arch
 apt-get -y install linux-headers-$(uname -r)

--- a/ci/amd64/packer.build.amd64-debian.sh
+++ b/ci/amd64/packer.build.amd64-debian.sh
@@ -31,6 +31,13 @@ else
 	branch=master
 fi
 
+# optional pull-request number: marks an unverified PR test build
+if [ $# -gt 2 ]; then
+	pr_number=$3
+else
+	pr_number=""
+fi
+
 # Resolve latest Debian 13 amd64 netinst ISO from SHA256SUMS.
 # This avoids 404s and checksum mismatches when Debian point releases rotate.
 debian_major=${DEBIAN_MAJOR:-13}
@@ -126,7 +133,7 @@ else
 	exit 1
 fi
 
-vars="-var github_user=${github_user} -var branch=${branch} -var iso_name=${latest_iso_name} -var iso_checksum=${latest_iso_checksum}"
+vars="-var github_user=${github_user} -var branch=${branch} -var pr_number=${pr_number} -var iso_name=${latest_iso_name} -var iso_checksum=${latest_iso_checksum}"
 
 # Build the image
 echo "# Build the image with: github_user=${github_user} branch=${branch}"

--- a/ci/arm64-rpi/arm64-rpi.pkr.hcl
+++ b/ci/arm64-rpi/arm64-rpi.pkr.hcl
@@ -1,5 +1,9 @@
 variable "github_user" {}
 variable "branch" {}
+# set to the pull-request number for PR CI builds: skips the code
+# signature verification and labels the image as an unverified test build.
+# Empty for master (production) builds where verification is mandatory.
+variable "pr_number" { default = "" }
 
 source "arm" "joininbox-arm64-rpi" {
   file_checksum_type    = "sha256"
@@ -52,7 +56,8 @@ build {
   provisioner "shell" {
     environment_vars = [
       "github_user=${var.github_user}",
-      "branch=${var.branch}"
+      "branch=${var.branch}",
+      "pr_number=${var.pr_number}"
     ]
     script = "./joininbox.sh"
   }

--- a/ci/arm64-rpi/arm64-rpi.sh
+++ b/ci/arm64-rpi/arm64-rpi.sh
@@ -12,9 +12,16 @@ else
   branch=master
 fi
 
+# optional pull-request number: marks an unverified PR test build
+if [ $# -gt 2 ]; then
+  pr_number=$3
+else
+  pr_number=""
+fi
+
 # Build the image in docker
 echo -e "\nBuild Packer image..."
 # from https://hub.docker.com/r/mkaczanowski/packer-builder-arm/tags
 docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build \
  mkaczanowski/packer-builder-arm:1.0.4@sha256:df09a8e249a292f10ca9b8cfd73420f5b987b6ac337d4ef28b6f4a8e61118822 \
- build -var "github_user=${github_user}" -var "branch=${branch}" arm64-rpi.pkr.hcl
+ build -var "github_user=${github_user}" -var "branch=${branch}" -var "pr_number=${pr_number}" arm64-rpi.pkr.hcl

--- a/ci/arm64-rpi/joininbox.sh
+++ b/ci/arm64-rpi/joininbox.sh
@@ -7,4 +7,4 @@ echo '# Download the build_joininbox.sh script ...'
 wget https://raw.githubusercontent.com/${github_user}/joininbox/${branch}/build_joininbox.sh
 
 echo '# Build Joininbox ...'
-sudo bash build_joininbox.sh "${github_user}" "${branch}" "commit"
+sudo env JOININBOX_PR_NUMBER="${pr_number}" bash build_joininbox.sh "${github_user}" "${branch}" "commit"

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -12,6 +12,16 @@ BACKTITLE="JoininBox GUI $currentJBtag network:$network IP:$localip"
 TITLE="JoininBox $currentJBtag $network"
 MENU="
 Choose from the options:"
+
+# warn prominently on top of the menu if this is an unverified
+# pull-request test image (labeled by build_joininbox.sh)
+if [ -f /etc/joininbox-build-info ]; then
+  pr_build=$(grep -E "^pr_build=" /etc/joininbox-build-info | cut -d= -f2)
+  MENU="
+!!! UNVERIFIED PR BUILD #${pr_build} - TESTING ONLY !!!
+Choose from the options:"
+  HEIGHT=$((HEIGHT + 1))
+fi
 OPTIONS=()
 
 # Basic Options


### PR DESCRIPTION
## Problem

Both image builds currently fail in packer on every PR:

**arm64-rpi-image-build** — `dpkg` halts on the interactive `initramfs.conf` conffile prompt (`Y/I/N/O/D/Z`) during kernel package configuration triggered by `apt-get upgrade -f -y`, then cascades:
```
*** initramfs.conf (Y/I/N/O/D/Z) [default=N] ? dpkg: error processing package initramfs-tools-core (--configure):
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

**amd64-image-build** — two issues:
1. debconf falls back through Dialog → Readline → Teletype frontends (no controlling tty in packer), the same unguarded conffile-prompt exposure as arm64
2. hard failure: `E: Package 'netcat' has no installation candidate` — the `netcat` metapackage was removed in Debian trixie

Additionally, the mandatory PGP source verification in `build_joininbox.sh` fails on every PR build because PR head commits come from forks and are not signed by the pinned maintainer keys:
```
# BUILD FAILED --> PGP verification not OK / signature(0) verify(0)
```

## Fix

**Noninteractive package management (build-time only):**
- `build_joininbox.sh` + `ci/amd64/debian/scripts/update.sh`: export `DEBIAN_FRONTEND=noninteractive` and install `/etc/apt/apt.conf.d/90joininbox-noninteractive` with `Dpkg::Options { "--force-confdef"; "--force-confold"; }` before the upgrades — conffile prompts resolve to the default action and keep the existing config
- The dropin is **removed at the end of `build_joininbox.sh`** so it does not ship in deployed images; running nodes keep the default interactive conffile handling
- `build_joininbox.sh`: install `netcat-openbsd` when the `netcat` metapackage is unavailable (trixie)

**PR builds skip code signature verification, labeled as test images:**
- `pull_request` workflow runs pass the PR number down the chain: workflow `JOININBOX_PR_NUMBER` → build script arg → packer `pr_number` var → provisioner env → `build_joininbox.sh`
- When set, verification is skipped with a prominent warning and the image is labeled in `/etc/joininbox-build-info` (pr number, fork, branch, build date)
- The **main menu shows `!!! UNVERIFIED PR BUILD #<N> - TESTING ONLY !!!` on top** whenever that label is present, so a flashed PR image cannot be mistaken for a production build
- Artifact names carry a `-pr<N>` suffix
- `push` to master and `workflow_dispatch` never set the variable → **production images keep mandatory signature verification**

**Note:** for `pull_request` events the workflow YAML runs from the base branch, so this PR's own image-build checks still execute the old master workflow and stay red on verification. The new path activates after merge; PRs opened or rebased afterwards build green.

Verified: `bash -n` / `sh -n` clean on all modified scripts.