### PR TITLE
fix(ci): fall back to GITHUB_REF_NAME when GITHUB_HEAD_REF is empty

### DIFF
--- a/.github/workflows/amd64-image-build.yml
+++ b/.github/workflows/amd64-image-build.yml
@@ -50,9 +50,9 @@ jobs:
 
       - name: Run the build script
         run: |
-          echo "Running with: ${{steps.set_values.outputs.github_user}} $GITHUB_HEAD_REF"
+          echo "Running with: ${{steps.set_values.outputs.github_user}} ${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
           cd ci/amd64
-          bash packer.build.amd64-debian.sh ${{steps.set_values.outputs.github_user}} $GITHUB_HEAD_REF "$JOININBOX_PR_NUMBER"
+          bash packer.build.amd64-debian.sh ${{steps.set_values.outputs.github_user}} ${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}} "$JOININBOX_PR_NUMBER"
 
       - name: Compute checksum of the raw image
         run: |

--- a/.github/workflows/arm64-rpi-image-build.yml
+++ b/.github/workflows/arm64-rpi-image-build.yml
@@ -57,9 +57,9 @@ jobs:
 
       - name: Run the build script
         run: |
-          echo "Running with: ${{steps.set_values.outputs.github_user}} $GITHUB_HEAD_REF"
+          echo "Running with: ${{steps.set_values.outputs.github_user}} ${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
           cd ci/arm64-rpi
-          bash arm64-rpi.sh ${{steps.set_values.outputs.github_user}} $GITHUB_HEAD_REF "$JOININBOX_PR_NUMBER"
+          bash arm64-rpi.sh ${{steps.set_values.outputs.github_user}} ${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}} "$JOININBOX_PR_NUMBER"
 
       - name: Compute checksum of the raw image
         run: |

--- a/ci/amd64/packer.build.amd64-debian.sh
+++ b/ci/amd64/packer.build.amd64-debian.sh
@@ -25,9 +25,11 @@ else
 	github_user=openoms
 fi
 
-if [ $# -gt 1 ]; then
+if [ $# -gt 1 ] && [ -n "$2" ]; then
 	branch=$2
 else
+	# an explicitly passed empty branch would break the raw.githubusercontent
+	# fetch URL (404) - fall back to master
 	branch=master
 fi
 

--- a/ci/arm64-rpi/arm64-rpi.sh
+++ b/ci/arm64-rpi/arm64-rpi.sh
@@ -6,9 +6,11 @@ else
   github_user=openoms
 fi
 
-if [ $# -gt 1 ]; then
+if [ $# -gt 1 ] && [ -n "$2" ]; then
   branch=$2
 else
+  # an explicitly passed empty branch would break the raw.githubusercontent
+  # fetch URL (404) - fall back to master
   branch=master
 fi
 


### PR DESCRIPTION
## Problem

`GITHUB_HEAD_REF` is only set for `pull_request` events. On push to master the branch argument to the build scripts was empty, so the amd64 build downloaded:

```
https://raw.githubusercontent.com/openoms/joininbox//build_joininbox.sh
```

which 404s and fails the image build (wget exit 8) — see the master run after #196 merged.

## Fix

Use `${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}` in both image-build workflows so push builds use the pushed branch name.

Related: the arm64 workflow had the same latent bug (its current master failure is a separate transient loop-device issue).