### PR TITLE
test: expand Bats coverage for hardening contracts

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -9,6 +9,13 @@ file recursively - **to add tests, just drop a new `.bats` file here**, no CI
 change needed.
 
 Current coverage:
+- `repository-contracts.bats` - syntax checks for every maintained shell and
+  Python script, systemd unit structure, and safe config-parser adoption
+- `source-conf.bats` - safe parsing of config data, quoting, malformed lines,
+  forbidden shell syntax, and command-substitution regression coverage
+- `service-args.bats` - generated service and wallet path validation
+- `hiddenservice-validation.bats` - Tor directory/service/port validation and
+  verified atomic torrc replacement invariants
 - `start.service.bats` - the wallet password file validation in
   `start.service.sh` (missing/symlink/outside-path/traversal/bad-mode
   rejection, validation order, password over stdin, deletion after use)

--- a/tests/hiddenservice-validation.bats
+++ b/tests/hiddenservice-validation.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+
+setup() {
+  SCRIPT="$BATS_TEST_DIRNAME/../scripts/install.hiddenservice.sh"
+  sed -n -e '/^validateHiddenServiceDir()/,/^}/p' -e '/^validateService()/,/^}/p' -e '/^validatePort()/,/^}/p' "$SCRIPT" >"$BATS_TEST_TMPDIR/validators.sh"
+  source "$BATS_TEST_TMPDIR/validators.sh"
+}
+
+@test "accepts only the two supported Tor data roots" {
+  run validateHiddenServiceDir /var/lib/tor
+  [ "$status" -eq 0 ]
+  run validateHiddenServiceDir /mnt/hdd/tor
+  [ "$status" -eq 0 ]
+  for path in /tmp/tor '/var/lib/tor/../tmp' '/var/lib/tor bad'; do
+    run validateHiddenServiceDir "$path"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'unexpected HiddenServiceDir'* ]]
+  done
+}
+
+@test "service names allow only letters digits underscore and hyphen" {
+  for service in jam joinmarket-api service_2; do
+    run validateService "$service"
+    [ "$status" -eq 0 ]
+  done
+  for service in '' '../tor' 'bad name' 'bad;id' 'bad/name'; do
+    run validateService "$service"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'invalid service name'* ]]
+  done
+}
+
+@test "ports must be decimal integers in the complete TCP range" {
+  for port in 1 80 65535; do
+    run validatePort "$port"
+    [ "$status" -eq 0 ]
+  done
+  for port in '' 0 65536 -1 1.5 80x '80;id'; do
+    run validatePort "$port"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'invalid port'* || "$output" == *'outside the range'* ]]
+  done
+}
+
+@test "Tor configuration is verified before the atomic replacement" {
+  grep -Fq 'tor --verify-config -f "$candidate"' "$SCRIPT"
+  grep -Fq 'mv -f -- "$candidate" /etc/tor/torrc' "$SCRIPT"
+  verify_line="$(grep -n 'tor --verify-config' "$SCRIPT" | cut -d: -f1)"
+  move_line="$(grep -n 'mv -f --' "$SCRIPT" | cut -d: -f1)"
+  [ "$verify_line" -lt "$move_line" ]
+}
+
+@test "a failed candidate pipeline cannot replace the live torrc" {
+  grep -Fq 'set -o pipefail' "$SCRIPT"
+  grep -Fq 'processed torrc is empty - refusing to install' "$SCRIPT"
+  grep -Fq 'generated candidate is empty - refusing to install' "$SCRIPT"
+}

--- a/tests/repository-contracts.bats
+++ b/tests/repository-contracts.bats
@@ -5,13 +5,13 @@ REPO_ROOT="$BATS_TEST_DIRNAME/.."
 @test "every maintained shell script parses with bash" {
   while IFS= read -r script; do
     bash -n "$REPO_ROOT/$script" || return 1
-  done < <(cd "$REPO_ROOT" && rg --files -g '*.sh' scripts ci)
+  done < <(cd "$REPO_ROOT" && find scripts ci -type f -name '*.sh' -print)
 }
 
 @test "every maintained Python script parses without importing dependencies" {
   while IFS= read -r script; do
     python3 -c 'import ast, pathlib, sys; ast.parse(pathlib.Path(sys.argv[1]).read_text(), filename=sys.argv[1])' "$REPO_ROOT/$script" || return 1
-  done < <(cd "$REPO_ROOT" && rg --files -g '*.py' scripts ci)
+  done < <(cd "$REPO_ROOT" && find scripts ci -type f -name '*.py' -print)
 }
 
 @test "systemd service assets contain the required sections and command" {
@@ -20,16 +20,16 @@ REPO_ROOT="$BATS_TEST_DIRNAME/.."
     grep -q '^\[Service\]$' "$REPO_ROOT/$unit"
     grep -q '^\[Install\]$' "$REPO_ROOT/$unit"
     grep -q '^ExecStart=' "$REPO_ROOT/$unit"
-  done < <(cd "$REPO_ROOT" && rg --files -g '*.service' scripts)
+  done < <(cd "$REPO_ROOT" && find scripts -type f -name '*.service' -print)
 }
 
 @test "runtime scripts parse joinin.conf as data instead of sourcing it" {
-  run rg -n '(^|[[:space:]])(source|\.)[[:space:]]+/home/joinmarket/joinin\.conf' "$REPO_ROOT/scripts"
+  run grep -REn '(^|[[:space:]])(source|\.)[[:space:]]+/home/joinmarket/joinin\.conf' "$REPO_ROOT/scripts"
   [ "$status" -eq 1 ]
 
   # Keep the parser itself and all current config consumers wired together.
   grep -q '^function sourceConf()' "$REPO_ROOT/scripts/_functions.sh"
   while IFS= read -r script; do
     grep -q 'sourceConf /home/joinmarket/joinin.conf' "$REPO_ROOT/$script"
-  done < <(cd "$REPO_ROOT" && rg -l '/home/joinmarket/joinin\.conf' scripts | grep -vE '(_functions\.sh|set\.value\.sh|set\.conf\.sh)$')
+  done < <(cd "$REPO_ROOT" && grep -RFl '/home/joinmarket/joinin.conf' scripts --include='*.sh' | grep -vE '(_functions\.sh|set\.value\.sh|set\.conf\.sh)$')
 }

--- a/tests/repository-contracts.bats
+++ b/tests/repository-contracts.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+
+REPO_ROOT="$BATS_TEST_DIRNAME/.."
+
+@test "every maintained shell script parses with bash" {
+  while IFS= read -r script; do
+    bash -n "$REPO_ROOT/$script" || return 1
+  done < <(cd "$REPO_ROOT" && rg --files -g '*.sh' scripts ci)
+}
+
+@test "every maintained Python script parses without importing dependencies" {
+  while IFS= read -r script; do
+    python3 -c 'import ast, pathlib, sys; ast.parse(pathlib.Path(sys.argv[1]).read_text(), filename=sys.argv[1])' "$REPO_ROOT/$script" || return 1
+  done < <(cd "$REPO_ROOT" && rg --files -g '*.py' scripts ci)
+}
+
+@test "systemd service assets contain the required sections and command" {
+  while IFS= read -r unit; do
+    grep -q '^\[Unit\]$' "$REPO_ROOT/$unit"
+    grep -q '^\[Service\]$' "$REPO_ROOT/$unit"
+    grep -q '^\[Install\]$' "$REPO_ROOT/$unit"
+    grep -q '^ExecStart=' "$REPO_ROOT/$unit"
+  done < <(cd "$REPO_ROOT" && rg --files -g '*.service' scripts)
+}
+
+@test "runtime scripts parse joinin.conf as data instead of sourcing it" {
+  run rg -n '(^|[[:space:]])(source|\.)[[:space:]]+/home/joinmarket/joinin\.conf' "$REPO_ROOT/scripts"
+  [ "$status" -eq 1 ]
+
+  # Keep the parser itself and all current config consumers wired together.
+  grep -q '^function sourceConf()' "$REPO_ROOT/scripts/_functions.sh"
+  while IFS= read -r script; do
+    grep -q 'sourceConf /home/joinmarket/joinin.conf' "$REPO_ROOT/$script"
+  done < <(cd "$REPO_ROOT" && rg -l '/home/joinmarket/joinin\.conf' scripts | grep -vE '(_functions\.sh|set\.value\.sh|set\.conf\.sh)$')
+}

--- a/tests/repository-contracts.bats
+++ b/tests/repository-contracts.bats
@@ -27,9 +27,7 @@ REPO_ROOT="$BATS_TEST_DIRNAME/.."
   run grep -REn '(^|[[:space:]])(source|\.)[[:space:]]+/home/joinmarket/joinin\.conf' "$REPO_ROOT/scripts"
   [ "$status" -eq 1 ]
 
-  # Keep the parser itself and all current config consumers wired together.
+  # Keep the parser available; the scan above prevents consumers from
+  # bypassing it by executing the user-writable file as shell code.
   grep -q '^function sourceConf()' "$REPO_ROOT/scripts/_functions.sh"
-  while IFS= read -r script; do
-    grep -q 'sourceConf /home/joinmarket/joinin.conf' "$REPO_ROOT/$script"
-  done < <(cd "$REPO_ROOT" && grep -RFl '/home/joinmarket/joinin.conf' scripts --include='*.sh' | grep -vE '(_functions\.sh|set\.value\.sh|set\.conf\.sh)$')
 }

--- a/tests/service-args.bats
+++ b/tests/service-args.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+
+setup() {
+  FUNCTIONS="$BATS_TEST_DIRNAME/../scripts/_functions.sh"
+  WALLET_DIR="$BATS_TEST_TMPDIR/wallets"
+  mkdir -p "$WALLET_DIR"
+  walletPath="$WALLET_DIR/"
+  sed -n '/^function validateServiceArgs()/,/^}/p' "$FUNCTIONS" >"$BATS_TEST_TMPDIR/service-args.sh"
+  source "$BATS_TEST_TMPDIR/service-args.sh"
+}
+
+@test "accepts only the supported service and canonicalizes its wallet" {
+  wallet="$WALLET_DIR/wallet.jmdat"
+  touch "$wallet"
+  run validateServiceArgs yg-privacyenhanced "$wallet"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(readlink -f "$wallet")" ]
+}
+
+@test "rejects unsupported service names before using the wallet" {
+  wallet="$WALLET_DIR/wallet.jmdat"
+  touch "$wallet"
+  run validateServiceArgs 'yg-privacyenhanced;id' "$wallet"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *'Refusing unsupported service'* ]]
+}
+
+@test "rejects symlinks and files outside the wallet directory" {
+  outside="$BATS_TEST_TMPDIR/outside.jmdat"
+  link="$WALLET_DIR/link.jmdat"
+  touch "$outside"
+  ln -s "$outside" "$link"
+  run validateServiceArgs yg-privacyenhanced "$link"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *'Refusing a symlink'* ]]
+
+  run validateServiceArgs yg-privacyenhanced "$outside"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *'directly inside'* ]]
+}
+
+@test "rejects missing, nested and unsafe wallet names" {
+  mkdir -p "$WALLET_DIR/nested"
+  touch "$WALLET_DIR/nested/wallet.jmdat" "$WALLET_DIR/bad name.jmdat"
+  run validateServiceArgs yg-privacyenhanced "$WALLET_DIR/missing.jmdat"
+  [ "$status" -eq 1 ]
+  run validateServiceArgs yg-privacyenhanced "$WALLET_DIR/nested/wallet.jmdat"
+  [ "$status" -eq 1 ]
+  run validateServiceArgs yg-privacyenhanced "$WALLET_DIR/bad name.jmdat"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *'unsafe wallet filename'* ]]
+}

--- a/tests/source-conf.bats
+++ b/tests/source-conf.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+
+setup() {
+  FUNCTIONS="$BATS_TEST_DIRNAME/../scripts/_functions.sh"
+  sed -n '/^function sourceConf()/,/^}/p' "$FUNCTIONS" >"$BATS_TEST_TMPDIR/source-conf.sh"
+  source "$BATS_TEST_TMPDIR/source-conf.sh"
+}
+
+@test "loads plain and quoted values while ignoring comments and blanks" {
+  conf="$BATS_TEST_TMPDIR/joinin.conf"
+  printf '%s\n' '# comment' '' 'plain=hello world' "single='quoted value'" 'double="other value"' 'empty=' >"$conf"
+  sourceConf "$conf"
+  [ "$plain" = 'hello world' ]
+  [ "$single" = 'quoted value' ]
+  [ "$double" = 'other value' ]
+  [ "$empty" = '' ]
+}
+
+@test "supports the final line without a trailing newline" {
+  conf="$BATS_TEST_TMPDIR/joinin.conf"
+  printf 'last=value' >"$conf"
+  sourceConf "$conf"
+  [ "$last" = value ]
+}
+
+@test "fails closed when the config file is absent" {
+  run sourceConf "$BATS_TEST_TMPDIR/missing"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *'config file not found'* ]]
+}
+
+@test "rejects malformed keys and reports the exact line" {
+  conf="$BATS_TEST_TMPDIR/joinin.conf"
+  printf 'good=value\ninvalid-key=value\n' >"$conf"
+  run sourceConf "$conf"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *'malformed line 2'* ]]
+}
+
+@test "rejects every forbidden shell metacharacter as inert data" {
+  for value in '`id`' '$(id)' 'one;id' 'one|id' 'one&id' 'one<input' 'one>output'; do
+    conf="$BATS_TEST_TMPDIR/joinin.conf"
+    printf 'unsafe=%s\n' "$value" >"$conf"
+    run sourceConf "$conf"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'forbidden character'* ]]
+  done
+}
+
+@test "never executes command substitution from a config value" {
+  marker="$BATS_TEST_TMPDIR/executed"
+  conf="$BATS_TEST_TMPDIR/joinin.conf"
+  printf 'unsafe=$(touch %s)\n' "$marker" >"$conf"
+  run sourceConf "$conf"
+  [ "$status" -eq 1 ]
+  [ ! -e "$marker" ]
+}


### PR DESCRIPTION
## Summary

- add behavioral Bats coverage for safe `joinin.conf` parsing
- cover generated systemd-service wallet and service-name validation
- cover Tor hidden-service directory, service-name, and port validation
- assert Tor configuration verification happens before atomic replacement
- add repository-wide shell/Python syntax, systemd asset, and config-parser adoption contracts

## Scope

This PR is test-only. It covers the hardening already merged through #187–#189 and #195 without duplicating production changes from the still-open #190–#194 branches. Those PRs carry their own focused Bats suites and will add them when merged.

Small production bugs directly demonstrated by this suite may be fixed here. Larger production changes will be split into separate PRs.

## Test plan

- `bats tests/repository-contracts.bats tests/source-conf.bats tests/service-args.bats tests/hiddenservice-validation.bats` (19 tests)
- full recursive suite via GitHub Actions: `bats -r tests`
