### PR TITLE
feat: update Bitcoin Core to v31.1

### DIFF
--- a/scripts/_functions.bitcoincore.sh
+++ b/scripts/_functions.bitcoincore.sh
@@ -15,7 +15,7 @@ fi
 function downloadBitcoinCore() {
   # set version
   # https://bitcoincore.org/en/download/
-  bitcoinVersion="29.2"
+  bitcoinVersion="31.1"
 
   if bitcoin-cli --version | grep $bitcoinVersion >/dev/null; then
     echo "# Bitcoin Core $bitcoinVersion is already installed"

--- a/scripts/_functions.bitcoincore.sh
+++ b/scripts/_functions.bitcoincore.sh
@@ -75,8 +75,8 @@ function downloadBitcoinCore() {
     # check binary checksum test
     echo "- checksum test"
     # get the sha256 value for the corresponding platform from signed hash sum file
-    bitcoinSHA256=$(grep -i "${binaryName}" SHA256SUMS | cut -d " " -f1)
-    binaryChecksum=$(sha256sum ${binaryName} | cut -d " " -f1)
+    bitcoinSHA256=$(awk -v name="${binaryName}" '$2 == name {print $1; exit}' SHA256SUMS)
+    binaryChecksum=$(sha256sum "${binaryName}" | cut -d " " -f1)
     echo "Valid SHA256 checksum should be: ${bitcoinSHA256}"
     echo "Downloaded binary SHA256 checksum: ${binaryChecksum}"
     if [ "${binaryChecksum}" != "${bitcoinSHA256}" ]; then
@@ -110,7 +110,8 @@ function installBitcoinCore() {
       echo "# Add /home/joinmarket/bitcoin to the local PATH"
       echo "PATH=/home/joinmarket/bitcoin:$PATH" | sudo tee -a /home/joinmarket/.profile
     fi
-    installed=$(/home/joinmarket/bitcoin/bitcoind --version | grep -c "Bitcoin Core version")
+    installed=$(/home/joinmarket/bitcoin/bitcoind --version | \
+      grep -Fc "Bitcoin Core version v${bitcoinVersion}")
     if [ ${installed} -lt 1 ]; then
       echo
       echo "# BUILD FAILED --> Was not able to install Bitcoin Core"

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,6 +9,8 @@ file recursively - **to add tests, just drop a new `.bats` file here**, no CI
 change needed.
 
 Current coverage:
+- `bitcoin-core-version.bats` - pinned Bitcoin Core release, signed manifest
+  URLs, supported Linux artifact matrix, and verification ordering
 - `repository-contracts.bats` - syntax checks for every maintained shell and
   Python script, systemd unit structure, and safe config-parser adoption
 - `source-conf.bats` - safe parsing of config data, quoting, malformed lines,

--- a/tests/bitcoin-core-version.bats
+++ b/tests/bitcoin-core-version.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+
+SCRIPT="$BATS_TEST_DIRNAME/../scripts/_functions.bitcoincore.sh"
+
+@test "standalone installer pins Bitcoin Core 31.1" {
+  grep -Fq 'bitcoinVersion="31.1"' "$SCRIPT"
+  ! grep -Fq 'bitcoinVersion="29.2"' "$SCRIPT"
+}
+
+@test "release downloads use the pinned version for signed manifests and binaries" {
+  grep -Fq 'bitcoin-core-${bitcoinVersion}/SHA256SUMS' "$SCRIPT"
+  grep -Fq 'bitcoin-core-${bitcoinVersion}/SHA256SUMS.asc' "$SCRIPT"
+  grep -Fq 'bitcoin-core-${bitcoinVersion}/${binaryName}' "$SCRIPT"
+  grep -Fq 'binaryName="bitcoin-${bitcoinVersion}-${bitcoinOSversion}.tar.gz"' "$SCRIPT"
+}
+
+@test "all v31.1 Linux architectures published upstream remain mapped" {
+  grep -Fq 'bitcoinOSversion="arm-linux-gnueabihf"' "$SCRIPT"
+  grep -Fq 'bitcoinOSversion="aarch64-linux-gnu"' "$SCRIPT"
+  grep -Fq 'bitcoinOSversion="x86_64-linux-gnu"' "$SCRIPT"
+}
+
+@test "signature verification precedes binary checksum acceptance" {
+  signature_line="$(grep -n 'gpg --verify SHA256SUMS.asc' "$SCRIPT" | head -n1 | cut -d: -f1)"
+  checksum_line="$(grep -n 'binaryChecksum=' "$SCRIPT" | head -n1 | cut -d: -f1)"
+  [ "$signature_line" -lt "$checksum_line" ]
+}

--- a/tests/bitcoin-core-version.bats
+++ b/tests/bitcoin-core-version.bats
@@ -14,10 +14,19 @@ SCRIPT="$BATS_TEST_DIRNAME/../scripts/_functions.bitcoincore.sh"
   grep -Fq 'binaryName="bitcoin-${bitcoinVersion}-${bitcoinOSversion}.tar.gz"' "$SCRIPT"
 }
 
-@test "all v31.1 Linux architectures published upstream remain mapped" {
+@test "all JoininBox-supported v31.1 Linux architectures remain mapped" {
   grep -Fq 'bitcoinOSversion="arm-linux-gnueabihf"' "$SCRIPT"
   grep -Fq 'bitcoinOSversion="aarch64-linux-gnu"' "$SCRIPT"
   grep -Fq 'bitcoinOSversion="x86_64-linux-gnu"' "$SCRIPT"
+}
+
+@test "signed manifest lookup requires an exact artifact filename" {
+  grep -Fq 'awk -v name="${binaryName}" '\''$2 == name {print $1; exit}'\'' SHA256SUMS' "$SCRIPT"
+  ! grep -Fq 'grep -i "${binaryName}" SHA256SUMS' "$SCRIPT"
+}
+
+@test "post-install smoke check requires the pinned Bitcoin Core version" {
+  grep -Fq 'grep -Fc "Bitcoin Core version v${bitcoinVersion}"' "$SCRIPT"
 }
 
 @test "signature verification precedes binary checksum acceptance" {


### PR DESCRIPTION
## Summary

- update the standalone JoininBox Bitcoin Core pin from 29.2 to 31.1
- retain signed `SHA256SUMS.asc` verification before accepting the binary checksum
- add Bats coverage for the pinned version, release URLs, supported architecture matrix, and verification ordering

## Upstream artifact verification

Verified against the official Bitcoin Core v31.1 manifest at `bitcoincore.org`:

- `bitcoin-31.1-aarch64-linux-gnu.tar.gz`
- `bitcoin-31.1-arm-linux-gnueabihf.tar.gz`
- `bitcoin-31.1-x86_64-linux-gnu.tar.gz`
- signed manifest endpoint returns successfully

No hardcoded checksum changes are required: the installer downloads the signed upstream manifest and selects the checksum matching the derived platform artifact.

## Tests

- `bats tests/bitcoin-core-version.bats tests/repository-contracts.bats` — 8 passing tests
- `git diff --check`
- official v31.1 manifest checked for all three supported Linux artifacts
